### PR TITLE
Ignore .idea directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ Dockerfile
 
 .wharf-ci.yml
 docs
+.idea
 
 package.json
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /docs/
 *.swp
 *.exe
+.idea
 /node_modules/
 /package-lock.json


### PR DESCRIPTION
This ignores the .idea directory that gets created when opening the project with the Jetbrains GoLand IDE.

I have a thoery that the .gitignore file was created on windows without the `git config --global core.autocrlf true` set.