### PR TITLE
Fixed JSON schema for main.TestsResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v4.0.1 (WIP)
+
+- Fixed missing `failed` field from `main.TestsResults` in
+  `GET /build/{buildid}/tests-results`. (#25)
+
 ## v4.0.0 (2021-05-28)
 
 - Added [IETF RFC-7807](https://tools.ietf.org/html/rfc7807) compatible problem


### PR DESCRIPTION
Doing this:

```go
type TestsResults struct {
	Passed, Failed int
	Status         string
}
```

While it's a valid Go type with 3 different fields, the `swag init` generated the following:

```yaml
  main.TestsResults:
    properties:
      passed:
        type: integer
      status:
        type: string
    type: object
```

These changes turns it into this schema:

```yaml
  main.TestsResults:
    properties:
      failed:
        type: integer
      passed:
        type: integer
      status:
        enum:
        - Success
        - Failed
        - No tests
        type: string
    type: object
```
