### PR TITLE
Add endpoint PUT /token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added endpoint `PUT /provider` as an idempotent way of creating a
   provider. (#28)
 
+- Add endpoint `PUT /token` as an idempotent way of creating a
+  token. (#26)
+
 - Added environment var for setting bind address and port. (#29)
 
 - Fixed missing `failed` field from `main.TestsResults` in

--- a/token.go
+++ b/token.go
@@ -74,6 +74,7 @@ func (m TokenModule) getTokenHandler(c *gin.Context) {
 	} else if err != nil {
 		problem.WriteDBReadError(c, err, fmt.Sprintf(
 			"Failed fetching token by ID %d from database.", tokenID))
+		return
 	}
 
 	c.JSON(http.StatusOK, token)

--- a/token.go
+++ b/token.go
@@ -124,7 +124,6 @@ type TokenWithProviderID struct {
 // postTokenHandler godoc
 // @summary Add token to database.
 // @description Add token to database. Provider in post object has to exists or should be empty.
-// @description Provider will has to be updated token ID during this operation.
 // @tags token
 // @accept json
 // @produce json

--- a/token.go
+++ b/token.go
@@ -200,6 +200,11 @@ func (m TokenModule) putTokenHandler(c *gin.Context) {
 		return
 	}
 	var placedToken Token
-	m.Database.Where(token).FirstOrCreate(&placedToken)
+	if err := m.Database.Where(token).FirstOrCreate(&placedToken).Error; err != nil {
+		problem.WriteInvalidBindError(c, err, fmt.Sprintf(
+			"Failed fetch or create on token with token:%q and username:%q.",
+			token.Token, token.UserName))
+		return
+	}
 	c.JSON(http.StatusAccepted, placedToken)
 }

--- a/token.go
+++ b/token.go
@@ -27,6 +27,7 @@ func (m TokenModule) Register(g *gin.RouterGroup) {
 	{
 		token.GET("/:tokenid", m.getTokenHandler)
 		token.POST("", m.postTokenHandler)
+		token.PUT("", m.putTokenHandler)
 	}
 }
 
@@ -177,4 +178,30 @@ func (m TokenModule) postTokenHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, token)
+}
+
+// postTokenHandler godoc
+// @summary Put token in database.
+// @description Put token in database. Provider in post object has to exists or should be empty.
+// @description Provider will has to be updated token ID during this operation.
+// @tags token
+// @accept json
+// @produce json
+// @param token body TokenWithProviderID _ "token object"
+// @success 201 {object} Token
+// @failure 400 {object} problem.Response "Bad request"
+// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
+// @failure 404 {object} problem.Response "Referenced provider not found"
+// @failure 502 {object} problem.Response "Database is unreachable"
+// @router /token [put]
+func (m TokenModule) putTokenHandler(c *gin.Context) {
+	var token Token
+	err := c.ShouldBindJSON(&token)
+	if err != nil {
+		problem.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")
+		return
+	}
+	var placedToken Token
+	m.Database.Where(token).FirstOrCreate(&placedToken)
+	c.JSON(http.StatusAccepted, placedToken)
 }

--- a/token.go
+++ b/token.go
@@ -196,8 +196,7 @@ func (m TokenModule) postTokenHandler(c *gin.Context) {
 // @router /token [put]
 func (m TokenModule) putTokenHandler(c *gin.Context) {
 	var token Token
-	err := c.ShouldBindJSON(&token)
-	if err != nil {
+	if err := c.ShouldBindJSON(&token); err != nil {
 		problem.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")
 		return
 	}

--- a/token.go
+++ b/token.go
@@ -188,7 +188,7 @@ func (m TokenModule) postTokenHandler(c *gin.Context) {
 // @accept json
 // @produce json
 // @param token body TokenWithProviderID _ "token object"
-// @success 201 {object} Token
+// @success 200 {object} Token
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
@@ -206,5 +206,5 @@ func (m TokenModule) putTokenHandler(c *gin.Context) {
 			token.UserName))
 		return
 	}
-	c.JSON(http.StatusAccepted, placedToken)
+	c.JSON(http.StatusOK, placedToken)
 }

--- a/token.go
+++ b/token.go
@@ -182,8 +182,7 @@ func (m TokenModule) postTokenHandler(c *gin.Context) {
 
 // postTokenHandler godoc
 // @summary Put token in database.
-// @description Put token in database. Provider in post object has to exists or should be empty.
-// @description Provider will has to be updated token ID during this operation.
+// @description Creates a new token if a match is not found.
 // @tags token
 // @accept json
 // @produce json

--- a/token.go
+++ b/token.go
@@ -201,9 +201,9 @@ func (m TokenModule) putTokenHandler(c *gin.Context) {
 	}
 	var placedToken Token
 	if err := m.Database.Where(token).FirstOrCreate(&placedToken).Error; err != nil {
-		problem.WriteInvalidBindError(c, err, fmt.Sprintf(
-			"Failed fetch or create on token with token:%q and username:%q.",
-			token.Token, token.UserName))
+		problem.WriteDBWriteError(c, err, fmt.Sprintf(
+			"Failed fetch or create on token by username %q and token value.",
+			token.UserName))
 		return
 	}
 	c.JSON(http.StatusAccepted, placedToken)

--- a/token.go
+++ b/token.go
@@ -191,7 +191,6 @@ func (m TokenModule) postTokenHandler(c *gin.Context) {
 // @success 201 {object} Token
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
-// @failure 404 {object} problem.Response "Referenced provider not found"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /token [put]
 func (m TokenModule) putTokenHandler(c *gin.Context) {

--- a/token.go
+++ b/token.go
@@ -193,17 +193,17 @@ func (m TokenModule) postTokenHandler(c *gin.Context) {
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /token [put]
 func (m TokenModule) putTokenHandler(c *gin.Context) {
-	var token Token
-	if err := c.ShouldBindJSON(&token); err != nil {
+	var inputToken Token
+	if err := c.ShouldBindJSON(&inputToken); err != nil {
 		problem.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")
 		return
 	}
-	var placedToken Token
-	if err := m.Database.Where(token).FirstOrCreate(&placedToken).Error; err != nil {
+	var token Token
+	if err := m.Database.Where(inputToken).FirstOrCreate(&token).Error; err != nil {
 		problem.WriteDBWriteError(c, err, fmt.Sprintf(
 			"Failed fetch or create on token by username %q and token value.",
-			token.UserName))
+			inputToken.UserName))
 		return
 	}
-	c.JSON(http.StatusOK, placedToken)
+	c.JSON(http.StatusOK, token)
 }


### PR DESCRIPTION
This adds a code path for PUT for `/api/token`

This goes together with a few other PRs:
- The implementable interface https://github.com/iver-wharf/wharf-api-client-go/pull/8
- (This) The PUT /api/token https://github.com/iver-wharf/wharf-api/pull/26
- The PUT /api/provider https://github.com/iver-wharf/wharf-api/pull/28
- The gtihub-provider changes that require the rest https://github.com/iver-wharf/wharf-provider-github/pull/10