### PR TITLE
Add endpoint PUT /provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v4.1.0 (WIP)
 
+- Add endpoint PUT `PUT /provider`. (#28)
+
 - Added environment var for setting bind address and port. (#29)
 
 - Fixed missing `failed` field from `main.TestsResults` in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v4.1.0 (WIP)
 
-- Add endpoint PUT `PUT /provider`. (#28)
+- Added endpoint `PUT /provider` as an idempotent way of creating a
+  provider. (#28)
 
 - Added environment var for setting bind address and port. (#29)
 

--- a/provider.go
+++ b/provider.go
@@ -199,17 +199,17 @@ func (m ProviderModule) postProviderHandler(c *gin.Context) {
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /provider [put]
 func (m TokenModule) putProviderHandler(c *gin.Context) {
-	var provider Provider
-	if err := c.ShouldBindJSON(&provider); err != nil {
+	var inputProvider Provider
+	if err := c.ShouldBindJSON(&inputProvider); err != nil {
 		problem.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")
 		return
 	}
-	var placedProvider Provider
-	if err := m.Database.Where(token).FirstOrCreate(&placedProvider).Error; err != nil {
+	var provider Provider
+	if err := m.Database.Where(token).FirstOrCreate(&provider).Error; err != nil {
 		problem.WriteDBWriteError(c, err, fmt.Sprintf(
-			"Failed fetch or create on provider with name %q.",
-			provider.Name))
+			"Failed fetch or create on inputProvider with name %q.",
+			inputProvider.Name))
 		return
 	}
-	c.JSON(http.StatusOK, placedProvider)
+	c.JSON(http.StatusOK, provider)
 }

--- a/provider.go
+++ b/provider.go
@@ -185,3 +185,31 @@ func (m ProviderModule) postProviderHandler(c *gin.Context) {
 
 	c.JSON(http.StatusCreated, provider)
 }
+
+// putProviderHandler godoc
+// @summary Put provider in database.
+// @description Put provider in database.
+// @tags provider
+// @accept json
+// @produce json
+// @param provider body Provider _ "provider object"
+// @success 200 {object} Provider
+// @failure 400 {object} problem.Response "Bad request"
+// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
+// @failure 502 {object} problem.Response "Database is unreachable"
+// @router /provider [put]
+func (m TokenModule) putProviderHandler(c *gin.Context) {
+	var provider Provider
+	if err := c.ShouldBindJSON(&provider); err != nil {
+		problem.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")
+		return
+	}
+	var placedProvider Provider
+	if err := m.Database.Where(token).FirstOrCreate(&placedProvider).Error; err != nil {
+		problem.WriteDBWriteError(c, err, fmt.Sprintf(
+			"Failed fetch or create on provider with name %q.",
+			provider.Name))
+		return
+	}
+	c.JSON(http.StatusOK, placedProvider)
+}

--- a/provider.go
+++ b/provider.go
@@ -198,14 +198,14 @@ func (m ProviderModule) postProviderHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /provider [put]
-func (m TokenModule) putProviderHandler(c *gin.Context) {
+func (m ProviderModule) putProviderHandler(c *gin.Context) {
 	var inputProvider Provider
 	if err := c.ShouldBindJSON(&inputProvider); err != nil {
 		problem.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")
 		return
 	}
 	var provider Provider
-	if err := m.Database.Where(token).FirstOrCreate(&provider).Error; err != nil {
+	if err := m.Database.Where(inputProvider).FirstOrCreate(&provider).Error; err != nil {
 		problem.WriteDBWriteError(c, err, fmt.Sprintf(
 			"Failed fetch or create on inputProvider with name %q.",
 			inputProvider.Name))

--- a/provider.go
+++ b/provider.go
@@ -39,6 +39,7 @@ func (m ProviderModule) Register(g *gin.RouterGroup) {
 	{
 		provider.GET("/:providerid", m.getProviderHandler)
 		provider.POST("", m.postProviderHandler)
+		provider.PUT("", m.putProviderHandler)
 	}
 }
 

--- a/provider.go
+++ b/provider.go
@@ -188,7 +188,7 @@ func (m ProviderModule) postProviderHandler(c *gin.Context) {
 
 // putProviderHandler godoc
 // @summary Put provider in database.
-// @description Put provider in database.
+// @description Creates a new provider if a match is not found.
 // @tags provider
 // @accept json
 // @produce json


### PR DESCRIPTION
This adds a code path for PUT for /api/provider

This goes together with a few other PRs:
- The implementable interface https://github.com/iver-wharf/wharf-api-client-go/pull/8
- The PUT /api/token https://github.com/iver-wharf/wharf-api/pull/26
- (This) The PUT /api/provider https://github.com/iver-wharf/wharf-api/pull/28
- The gtihub-provider changes that require the rest https://github.com/iver-wharf/wharf-provider-github/pull/10