### PR TITLE
Release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v4.1.0 (WIP)
+## v4.1.0 (2021-04-14)
 
 - Added endpoint `PUT /provider` as an idempotent way of creating a
   provider. (#28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v4.1.0 (2021-04-14)
+## v4.1.0 (2021-06-10)
 
 - Added endpoint `PUT /provider` as an idempotent way of creating a
   provider. (#28)


### PR DESCRIPTION
This is needed to merge https://github.com/iver-wharf/wharf-provider-github/pull/10

## New in v4.1.0

- Added endpoint `PUT /provider` as an idempotent way of creating a
  provider. (#28)
- Add endpoint `PUT /token` as an idempotent way of creating a
  token. (#26)
- Added environment var for setting bind address and port. (#29)
- Fixed missing `failed` field from `main.TestsResults` in
  `GET /build/{buildid}/tests-results`. (#25)