### PR TITLE
Updated Alpine Docker image to 3.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v4.1.1 (WIP)
+
+- Changed version of Alpine Docker image used as the base image from 3.13.4
+  -> 3.13.5. (#31)
+
 ## v4.1.0 (2021-06-10)
 
 - Added endpoint `PUT /provider` as an idempotent way of creating a

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN deploy/update-version.sh version.yaml \
 		&& CGO_ENABLED=0 go build -o main \
 		&& go test -v ./...
 
-FROM alpine:3.13.4 AS final
+FROM alpine:3.13.5 AS final
 RUN apk add --no-cache ca-certificates
 WORKDIR /app
 COPY --from=build /src/main ./


### PR DESCRIPTION
Got a vulnerability warning from quay.io:

> CVE-2021-30139: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30139
> CVE-2020-28928: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28928
>
> https://quay.io/repository/iver-wharf/wharf-api/manifest/sha256:d2d805a6ee9d4a99b5a759b9b15fde617f4e66b5952b70d7539118b05e42eadf?tab=vulnerabilities

This is a wild guess if that fixes it. Just assuming.
