### PR TITLE
Release v4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v4.1.1 (WIP)
+## v4.1.1 (2021-07-12)
 
 - Changed version of Docker base images:
 


### PR DESCRIPTION
Most important thing here is the security warning we got on the built Docker image for v4.1.0: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30139
