### PR TITLE
Updated golang & alpine Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v4.1.1 (WIP)
 
-- Changed version of Alpine Docker image used as the base image from 3.13.4
-  -> 3.13.5. (#31)
+- Changed version of Docker base images:
+
+  - Alpine: 3.13.4 -> 3.14.0 (#31, #36)
+  - Golang: 1.13.4 -> 1.16.5 (#36)
 
 - Changed version of GORMv2 from v1.20.12 to v1.21.11. No major changes, but as
   a bug in GORM was fixed we could finally move to the latest version. (#34)
-  
+
 - Changed references to wharf-core pkg/problem and pkg/ginutil. (#33)
 
 ## v4.1.0 (2021-06-10)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4 AS build
+FROM golang:1.16.5 AS build
 WORKDIR /src
 RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
 COPY go.mod go.sum /src/
@@ -14,7 +14,7 @@ RUN deploy/update-version.sh version.yaml \
 		&& CGO_ENABLED=0 go build -o main \
 		&& go test -v ./...
 
-FROM alpine:3.13.5 AS final
+FROM alpine:3.14.0 AS final
 RUN apk add --no-cache ca-certificates
 WORKDIR /app
 COPY --from=build /src/main ./


### PR DESCRIPTION
Go: v1.16.4 -> v1.16.5
Alpine: v3.13.5 -> v3.14.0
