### PR TITLE
Logging via wharf-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   
 - Changed references to wharf-core pkg/problem and pkg/ginutil. (#33)
 
+- Changed all logging via `fmt.Print` and sirupsen/logrus to instead use the new
+  `github.com/iver-wharf/wharf-core/pkg/logger`. (#37)
+
+- Removed dependency on `github.com/sirupsen/logrus`. (#37)
+
 ## v4.1.0 (2021-06-10)
 
 - Added endpoint `PUT /provider` as an idempotent way of creating a

--- a/artifact.go
+++ b/artifact.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
-	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -243,9 +242,11 @@ func (m ArtifactModule) postBuildArtifactHandler(c *gin.Context) {
 				return
 			}
 
-			log.
-				WithFields(log.Fields{"filename": artifact.Name, "build": buildID, "artifact": artifact.ArtifactID}).
-				Infoln("File saved as artifact")
+			log.Info().
+				WithString("filename", artifact.Name).
+				WithUint("build", buildID).
+				WithUint("artifact", artifact.ArtifactID).
+				Message("File saved as artifact")
 		}
 	}
 

--- a/branch.go
+++ b/branch.go
@@ -3,8 +3,9 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"net/http"
+
+	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -169,7 +170,10 @@ func (m BranchModule) PutBranches(branches []Branch) error {
 					Delete(&oldDbBranch).Error; err != nil {
 					return err
 				}
-				fmt.Printf("Deleted branch: %v from project: %v \n", oldDbBranch.Name, oldDbBranch.ProjectID)
+				log.Info().
+					WithString("branch", oldDbBranch.Name).
+					WithUint("project", oldDbBranch.ProjectID).
+					Message("Deleted branch from project.")
 			}
 		}
 

--- a/build.go
+++ b/build.go
@@ -325,7 +325,7 @@ func (m BuildModule) updateBuildStatus(buildID uint, statusID BuildStatus) (Buil
 
 	if m.MessageQueue != nil {
 		if err := m.MessageQueue.PublishMessage(message); err != nil {
-			fmt.Printf("Send message fails: %v\n", err)
+			log.Error().WithError(err).Message("Failed sending build-status update message.")
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,15 +13,13 @@ require (
 	github.com/go-playground/validator/v10 v10.5.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/iver-wharf/messagebus-go v0.1.1
-	github.com/iver-wharf/wharf-core v0.0.0-20210610091057-c2f9a20c6a64
+	github.com/iver-wharf/wharf-core v0.0.0-20210702112246-1601d2a7dd23
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
-	github.com/jackc/pgx/v4 v4.11.0 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/swaggo/gin-swagger v1.3.0
 	github.com/swaggo/swag v1.7.0
@@ -31,6 +29,6 @@ require (
 	golang.org/x/sys v0.0.0-20210611083646-a4fc73990273 // indirect
 	golang.org/x/tools v0.1.3 // indirect
 	gopkg.in/guregu/null.v4 v4.0.0
-	gorm.io/driver/postgres v1.0.8
+	gorm.io/driver/postgres v1.1.0
 	gorm.io/gorm v1.21.11
 )

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
+github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -219,10 +221,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/iver-wharf/messagebus-go v0.1.1 h1:yzDcUSgKJpd5fij7oF93NA8i2s7IzVbapwJz8veBHqo=
 github.com/iver-wharf/messagebus-go v0.1.1/go.mod h1:Jan1LPVF2P1J+dTGcwE6QBI/+kxIXHMFgEDIE58wblc=
-github.com/iver-wharf/wharf-core v0.0.0-20210526121942-3bdbd8375f14 h1:W/bg8BnGdFBw6EB6ZUCCQvleEIWlmaDkmZ+6NgxK0gc=
-github.com/iver-wharf/wharf-core v0.0.0-20210526121942-3bdbd8375f14/go.mod h1:jlfPQyTWB/2wprBy65B6JnBsiahw7JinCBMNgB5KtjY=
-github.com/iver-wharf/wharf-core v0.0.0-20210610091057-c2f9a20c6a64 h1:AuC9RALHd25hUlUSo3jOoMxRXe2zv0ktYL+7RKwfpxc=
-github.com/iver-wharf/wharf-core v0.0.0-20210610091057-c2f9a20c6a64/go.mod h1:jlfPQyTWB/2wprBy65B6JnBsiahw7JinCBMNgB5KtjY=
+github.com/iver-wharf/wharf-core v0.0.0-20210702112246-1601d2a7dd23 h1:1Aj40X5mz6wNnZvqz5a0wI0z6ftoz4LCtH5lD2npgi4=
+github.com/iver-wharf/wharf-core v0.0.0-20210702112246-1601d2a7dd23/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
@@ -234,7 +234,6 @@ github.com/jackc/pgconn v0.0.0-20190831204454-2fabfa3c18b7/go.mod h1:ZJKsE/KZfsU
 github.com/jackc/pgconn v1.4.0/go.mod h1:Y2O3ZDF0q4mMacyWV3AstPJpeHXWGEetiFttmq5lahk=
 github.com/jackc/pgconn v1.5.0/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr0fAI=
 github.com/jackc/pgconn v1.5.1-0.20200601181101-fa742c524853/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr0fAI=
-github.com/jackc/pgconn v1.8.0/go.mod h1:1C2Pb36bGIP9QHGBYCjnyhqu7Rv3sGshaQUvmfGIB/o=
 github.com/jackc/pgconn v1.8.1 h1:ySBX7Q87vOMqKU2bbmKbUvtYhauDFclYbNDYIE1/h6s=
 github.com/jackc/pgconn v1.8.1/go.mod h1:JV6m6b6jhjdmzchES0drzCcYcAHS1OPD5xu3OZ/lE2g=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
@@ -262,7 +261,6 @@ github.com/jackc/pgtype v0.0.0-20190828014616-a8802b16cc59/go.mod h1:MWlu30kVJrU
 github.com/jackc/pgtype v1.2.0/go.mod h1:5m2OfMh1wTK7x+Fk952IDmI4nw3nPrvtQdM0ZT4WpC0=
 github.com/jackc/pgtype v1.3.1-0.20200510190516-8cd94a14c75a/go.mod h1:vaogEUkALtxZMCH411K+tKzNpwzCKU+AnPzBKZ+I+Po=
 github.com/jackc/pgtype v1.3.1-0.20200606141011-f6355165a91c/go.mod h1:cvk9Bgu/VzJ9/lxTO5R5sf80p0DiucVtN7ZxvaC4GmQ=
-github.com/jackc/pgtype v1.6.2/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
 github.com/jackc/pgtype v1.7.0 h1:6f4kVsW01QftE38ufBYxKciO6gyioXSC0ABIRLcZrGs=
 github.com/jackc/pgtype v1.7.0/go.mod h1:ZnHF+rMePVqDKaOfJVI4Q8IVvAQMryDlDkZnKOI75BE=
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
@@ -271,7 +269,6 @@ github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQ
 github.com/jackc/pgx/v4 v4.5.0/go.mod h1:EpAKPLdnTorwmPUUsqrPxy5fphV18j9q3wrfRXgo+kA=
 github.com/jackc/pgx/v4 v4.6.1-0.20200510190926-94ba730bb1e9/go.mod h1:t3/cdRQl6fOLDxqtlyhe9UWgfIi9R8+8v8GKV5TRA/o=
 github.com/jackc/pgx/v4 v4.6.1-0.20200606145419-4e5062306904/go.mod h1:ZDaNWkt9sW1JMiNn0kdYBaLelIhw7Pg4qd+Vk6tw7Hg=
-github.com/jackc/pgx/v4 v4.10.1/go.mod h1:QlrWebbs3kqEZPHCTGyxecvzG6tvIsYu+A5b1raylkA=
 github.com/jackc/pgx/v4 v4.11.0 h1:J86tSWd3Y7nKjwT/43xZBvpi04keQWx8gNC2YkdJhZI=
 github.com/jackc/pgx/v4 v4.11.0/go.mod h1:i62xJgdrtVDsnL3U8ekyrQXEwGNTRoG7/8r+CIdYfcc=
 github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
@@ -281,7 +278,6 @@ github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
-github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jinzhu/now v1.1.2 h1:eVKgfIdy9b6zbWBMgFpfDPoAMifwSZagU9HmEU6zgiI=
 github.com/jinzhu/now v1.1.2/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -332,6 +328,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
+github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -437,8 +435,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
-github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -610,7 +606,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -736,9 +731,9 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gorm.io/driver/postgres v1.0.8 h1:PAgM+PaHOSAeroTjHkCHCBIHHoBIf9RgPWGo8dF2DA8=
-gorm.io/driver/postgres v1.0.8/go.mod h1:4eOzrI1MUfm6ObJU/UcmbXyiHSs8jSwH95G5P5dxcAg=
-gorm.io/gorm v1.20.12/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
+gorm.io/driver/postgres v1.1.0 h1:afBljg7PtJ5lA6YUWluV2+xovIPhS+YiInuL3kUjrbk=
+gorm.io/driver/postgres v1.1.0/go.mod h1:hXQIwafeRjJvUm+OMxcFWyswJ/vevcpPLlGocwAwuqw=
+gorm.io/gorm v1.21.9/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 gorm.io/gorm v1.21.11 h1:CxkXW6Cc+VIBlL8yJEHq+Co4RYXdSLiMKNvgoZPjLK4=
 gorm.io/gorm v1.21.11/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"math/rand"
 	"net/http"
 	"os"
@@ -37,14 +36,14 @@ var log = logger.NewScoped("WHARF")
 // @basePath /api
 // @query.collection.format multi
 func main() {
+	logger.AddOutput(logger.LevelDebug, consolepretty.Default)
+
 	if err := loadEmbeddedVersionFile(); err != nil {
-		fmt.Println("Failed to read embedded version.yaml file:", err)
+		log.Error().WithError(err).Message("Failed to read embedded version.yaml file.")
 		os.Exit(1)
 	}
 
 	docs.SwaggerInfo.Version = AppVersion.Version
-
-	logger.AddOutput(logger.LevelDebug, consolepretty.Default)
 
 	if localCertFile, _ := os.LookupEnv("CA_CERTS"); localCertFile != "" {
 		client, err := httputils.NewClientWithCerts(localCertFile)

--- a/main.go
+++ b/main.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"math/rand"
 	"net/http"
 	"os"
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/iver-wharf/wharf-core/pkg/ginutil"
+	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/pkg/logger/consolepretty"
 
 	"github.com/dustin/go-broadcast"
 	"github.com/gin-contrib/cors"
@@ -22,6 +23,8 @@ import (
 )
 
 var logBroadcaster broadcast.Broadcaster
+
+var log = logger.NewScoped("WHARF")
 
 // @title Wharf main API
 // @description Wharf backend API that manages data storage for projects,
@@ -41,11 +44,12 @@ func main() {
 
 	docs.SwaggerInfo.Version = AppVersion.Version
 
-	initLogger(log.TraceLevel)
+	logger.AddOutput(logger.LevelDebug, consolepretty.Default)
+
 	if localCertFile, _ := os.LookupEnv("CA_CERTS"); localCertFile != "" {
 		client, err := httputils.NewClientWithCerts(localCertFile)
 		if err != nil {
-			log.WithError(err).Errorln("Failed to get net/http.Client with certs")
+			log.Error().WithError(err).Message("Failed to get net/http.Client with certs")
 			os.Exit(1)
 		}
 		http.DefaultClient = client
@@ -55,19 +59,19 @@ func main() {
 
 	config, err := getDatabaseConfigFromEnvironment()
 	if err != nil {
-		log.WithError(err).Errorln("Config error")
+		log.Error().WithError(err).Message("Config error")
 		os.Exit(1)
 	}
 
 	db, err := openDatabase(config)
 	if err != nil {
-		log.WithError(err).Errorln("Database error")
+		log.Error().WithError(err).Message("Database error")
 		os.Exit(2)
 	}
 
 	err = runDatabaseMigrations(db)
 	if err != nil {
-		log.WithError(err).Errorln("Migration error")
+		log.Error().WithError(err).Message("Migration error")
 		os.Exit(3)
 	}
 
@@ -80,7 +84,7 @@ func main() {
 
 	allowCors, ok := os.LookupEnv("ALLOW_CORS")
 	if ok && allowCors == "YES" {
-		log.Infoln("Allowing CORS")
+		log.Info().Message("Allowing CORS")
 		r.Use(cors.Default())
 	}
 
@@ -90,20 +94,20 @@ func main() {
 
 	mq, err := GetMQConnection()
 	if err != nil {
-		log.WithError(err).Errorln("Message queue error.")
+		log.Error().WithError(err).Message("Message queue error.")
 		os.Exit(4)
 	} else if mq == nil {
-		log.Infoln("RabbitMQ integration has been disabled in the config. Skipping connection instantiation.")
+		log.Info().Message("RabbitMQ integration has been disabled in the config. Skipping connection instantiation.")
 	} else {
 		err = mq.Connect()
 		if err != nil {
-			log.WithError(err).Errorln("Unable to connect to the RabbitMQ queue.")
+			log.Error().WithError(err).Message("Unable to connect to the RabbitMQ queue.")
 			os.Exit(5)
 		}
 
 		go func() {
 			<-mq.UnexpectedClose
-			log.Errorln("Unexpected RabbitMQ close")
+			log.Error().Message("Unexpected RabbitMQ close.")
 			os.Exit(6)
 		}()
 	}
@@ -137,41 +141,27 @@ func getBindAddress() string {
 func setupBasicAuth(router *gin.Engine) {
 	basicAuth := os.Getenv("BASIC_AUTH")
 	if basicAuth == "" {
-		log.Infoln("BASIC_AUTH environment variable not set, skipping basic-auth setup.")
+		log.Info().Message("BASIC_AUTH environment variable not set, skipping basic-auth setup.")
 		return
 	}
 
 	accounts := gin.Accounts{}
+	var accountNames []string
 
 	for _, account := range strings.Split(basicAuth, ",") {
 		split := strings.Split(account, ":")
+		user, pass := split[0], split[1]
 
-		accounts[split[0]] = split[1]
+		accounts[user] = pass
+		accountNames = append(accountNames, user)
 	}
 
-	log.WithField("accounts", accounts).Debugln("Setup:")
+	log.Debug().WithString("usernames", strings.Join(accountNames, ",")).
+		Messagef("Set up basic authentication for %d users.", len(accountNames))
 
 	router.Use(gin.BasicAuth(accounts))
 }
 
 func seed() {
 	rand.Seed(time.Now().UTC().UnixNano())
-}
-
-func initLogger(level log.Level) {
-	log.SetFormatter(&log.TextFormatter{
-		ForceColors:               true,
-		DisableColors:             false,
-		EnvironmentOverrideColors: false,
-		DisableTimestamp:          false,
-		FullTimestamp:             true,
-		TimestampFormat:           "",
-		DisableSorting:            false,
-		SortingFunc:               nil,
-		DisableLevelTruncation:    false,
-		QuoteEmptyFields:          false,
-		FieldMap:                  nil,
-		CallerPrettyfier:          nil,
-	})
-	log.SetLevel(level)
 }

--- a/migrations.go
+++ b/migrations.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -52,7 +51,7 @@ type constraintToDrop struct {
 }
 
 func dropOldConstraints(db *gorm.DB, constraints []constraintToDrop) error {
-	log.Debugf("Dropping %d old constraints", len(constraints))
+	log.Debug().WithInt("constraints", len(constraints)).Message("Dropping old constraints.")
 	for _, constraint := range constraints {
 		if err := dropOldConstraint(db, constraint.table, constraint.name); err != nil {
 			return err
@@ -63,24 +62,36 @@ func dropOldConstraints(db *gorm.DB, constraints []constraintToDrop) error {
 
 func dropOldConstraint(db *gorm.DB, table string, constraintName string) error {
 	if db.Migrator().HasConstraint(table, constraintName) {
-		log.Infof("Dropping old constraint for table %q: %q\n", table, constraintName)
+		log.Info().
+			WithString("table", table).
+			WithString("constraint", constraintName).
+			Message("Dropping old constraint.")
 		if err := db.Migrator().DropConstraint(table, constraintName); err != nil {
 			return fmt.Errorf("drop old constraint: %w", err)
 		}
 	} else {
-		log.Debugf("No old constraint to remove for table %q with name: %q\n", table, constraintName)
+		log.Debug().
+			WithString("table", table).
+			WithString("constraint", constraintName).
+			Message("No old constraint to remove.")
 	}
 	return nil
 }
 
 func dropOldColumn(db *gorm.DB, model interface{}, columnName string) error {
 	if db.Migrator().HasColumn(model, columnName) {
-		log.Infof("Dropping old column for type %T: %q\n", model, columnName)
+		log.Info().
+			WithString("column", columnName).
+			WithString("model", fmt.Sprintf("%T", model)).
+			Message("Dropping old column.")
 		if err := db.Migrator().DropColumn(model, columnName); err != nil {
 			return fmt.Errorf("drop old column: %w", err)
 		}
 	} else {
-		log.Debugf("No old column to remove for type %T with name: %q\n", model, columnName)
+		log.Debug().
+			WithString("column", columnName).
+			WithString("model", fmt.Sprintf("%T", model)).
+			Message("No old column to remove.")
 	}
 	return nil
 }

--- a/pkg/httputils/httpclient.go
+++ b/pkg/httputils/httpclient.go
@@ -6,7 +6,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/iver-wharf/wharf-core/pkg/logger"
 )
+
+var log = logger.New()
 
 // NewClientWithCerts creates a fresh net/http.Client populated with some
 // root CA certificates from file.
@@ -19,9 +23,9 @@ func NewClientWithCerts(localCertFile string) (*http.Client, error) {
 	// Get the SystemCertPool, continue with an empty pool on error
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()
-		fmt.Println("using empty cert pool")
+		log.Info().Message("Using empty cert pool.")
 	} else {
-		fmt.Println("using system cert pool")
+		log.Info().Message("Using system cert pool.")
 	}
 
 	// Read in the cert file
@@ -30,11 +34,12 @@ func NewClientWithCerts(localCertFile string) (*http.Client, error) {
 		return nil, fmt.Errorf("failed to append %q to RootCAs: %v", localCertFile, err)
 	}
 
-	fmt.Printf("loaded certs from %s\n", localCertFile)
+	log.Info().WithString("certsFile", localCertFile).Message("Loaded certs from file.")
 
 	// Append our cert to the system pool
 	if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-		fmt.Println("no certs appended, using system certs only")
+		log.Warn().WithString("certsFile", localCertFile).
+			Message("No new certs appended. Using system certs only.")
 	}
 
 	// Trust the augmented cert pool in our client


### PR DESCRIPTION
This just replaces the previous logging via logrus and `fmt.Print` with the new logging introduced in iver-wharf/wharf-core#10. No additional logging has been added nor has any been removed.

- Replaced logrus with wharf-core logging
- Replaced fmt.Print usage with wharf-core logging
