### PR TITLE
Add tzdata package to prod container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v4.2.0 (WIP)
 
+- Added support for the TZ environment variable (setting timezones ex.
+  `"Europe/Stockholm"`) through the tzdata package. (#40)
+
 - Added config loading from YAML files using
   `github.com/iver-wharf/wharf-core/pkg/config` together with new config models
   for configuring wharf-api. See `config.go` or the reference documentation on

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN deploy/update-version.sh version.yaml \
 		&& go test -v ./...
 
 FROM alpine:3.14.0 AS final
-RUN apk add --no-cache ca-certificates
-RUN apk add tzdata
+RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 COPY --from=build /src/main ./
 ENTRYPOINT ["/app/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN deploy/update-version.sh version.yaml \
 
 FROM alpine:3.14.0 AS final
 RUN apk add --no-cache ca-certificates
+RUN apk add tzdata
 WORKDIR /app
 COPY --from=build /src/main ./
 ENTRYPOINT ["/app/main"]


### PR DESCRIPTION
This change will allow setting timezone from the environment variable ex. TZ=Europe/Stockholm. 
Changing the timezone can be relevant during certain types of key/signature checks. 

Similar PRs opened for the other imaged repos:
https://github.com/iver-wharf/wharf-provider-github/pull/25
https://github.com/iver-wharf/wharf-provider-azuredevops/pull/20
https://github.com/iver-wharf/wharf-provider-gitlab/pull/20
https://github.com/iver-wharf/wharf-api/pull/40
