### PR TITLE
Fixed Makefile docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   be removed in the next major release (v5.0.0). Please refer to the new config
   schema seen in `config.go` and `config_example_test.go`. (#38)
 
-- Added Makefile to simplify building and developing the project locally. (#41)
+- Added Makefile to simplify building and developing the project locally.
+  (#41, #42)
 
 ## v4.1.1 (2021-07-12)
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: swag
 	go test -v ./...
 
 docker:
-	@echo docker build . \
+	docker build . \
 		-t "quay.io/iver-wharf/wharf-api:latest" \
 		-t "quay.io/iver-wharf/wharf-api:$(version)" \
 		--build-arg BUILD_VERSION="$(version)" \


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- `make docker` only echo'd `docker build` and did not actually run it. Technically called a "boo boo" from my end.

It did go through review, so I mean, we're all to blame :)
