### PR TITLE
Added /api/health and /api/ping endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added Makefile to simplify building and developing the project locally. (#41)
 
+- Fixed `/health` and `/ping` endpoints.
+
 ## v4.1.1 (2021-07-12)
 
 - Changed version of Docker base images:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added Makefile to simplify building and developing the project locally. (#41)
 
+- Added new endpoints `/api/ping` and `/api/health`. (#44)
+
 - Deprecated `/` and `/health` endpoints, soon to be moved to `/api/ping` and
   `/api/health` respectively, so they are aligned with the current Swagger
   documentation. (#44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added Makefile to simplify building and developing the project locally. (#41)
 
-- Fixed `/health` and `/ping` endpoints.
+- Fixed `/health` and `/` endpoints to instead listen on `/api/health` and
+  `/api/ping`, respectively, so they are aligned with the current Swagger
+  documentation. (#44)
 
 ## v4.1.1 (2021-07-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added Makefile to simplify building and developing the project locally. (#41)
 
-- Fixed `/health` and `/` endpoints to instead listen on `/api/health` and
-  `/api/ping`, respectively, so they are aligned with the current Swagger
+- Deprecated `/` and `/health` endpoints, soon to be moved to `/api/ping` and
+  `/api/health` respectively, so they are aligned with the current Swagger
   documentation. (#44)
 
 ## v4.1.1 (2021-07-12)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/iver-wharf/wharf-api
 go 1.16
 
 require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/dustin/go-broadcast v0.0.0-20171205050544-f664265f5a66
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-contrib/cors v1.3.1

--- a/main.go
+++ b/main.go
@@ -116,8 +116,8 @@ func main() {
 		r.Use(cors.New(corsConfig))
 	}
 
-  healthModule{}.DeprecatedRegister(r)
-  healthModule{}.Register(r.Group("/api"))
+	healthModule{}.DeprecatedRegister(r)
+	healthModule{}.Register(r.Group("/api"))
 
 	setupBasicAuth(r, config)
 

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 		log.Error().WithError(err).Message("Migration error")
 		os.Exit(3)
 	}
-  
+
 	mq, err := GetMQConnection(config.MQ)
 	if err != nil {
 		log.Error().WithError(err).Message("Message queue error.")
@@ -96,7 +96,7 @@ func main() {
 			os.Exit(6)
 		}()
 	}
-  
+
 	r := gin.New()
 	r.Use(
 		ginutil.LoggerWithConfig(ginutil.LoggerConfig{
@@ -120,7 +120,7 @@ func main() {
   healthModule{}.Register(r.Group("/api"))
 
 	setupBasicAuth(r, config)
-  
+
 	modules := []httpModule{
 		projectModule{Database: db, MessageQueue: mq, Config: &config},
 		buildModule{Database: db, MessageQueue: mq},

--- a/main.go
+++ b/main.go
@@ -91,8 +91,6 @@ func main() {
 		r.Use(cors.New(corsConfig))
 	}
 
-	HealthModule{}.Register(r)
-
 	setupBasicAuth(r, config)
 
 	mq, err := GetMQConnection(config.MQ)
@@ -120,7 +118,8 @@ func main() {
 		BuildModule{Database: db, MessageQueue: mq},
 		TokenModule{Database: db},
 		BranchModule{Database: db},
-		ProviderModule{Database: db}}
+		ProviderModule{Database: db},
+		HealthModule{}}
 
 	api := r.Group("/api")
 	for _, module := range modules {

--- a/main.go
+++ b/main.go
@@ -91,6 +91,8 @@ func main() {
 		r.Use(cors.New(corsConfig))
 	}
 
+	HealthModule{}.DeprecatedRegister(r)
+
 	setupBasicAuth(r, config)
 
 	mq, err := GetMQConnection(config.MQ)

--- a/messagequeue.go
+++ b/messagequeue.go
@@ -13,13 +13,13 @@ func GetMQConnection(config MQConfig) (*messagebus.MQConnection, error) {
 	}
 
 	return messagebus.NewConnection(
-		config.Host, 
+		config.Host,
 		config.Port,
-		config.Username, 
+		config.Username,
 		config.Password,
-		config.QueueName, 
+		config.QueueName,
 		config.VHost,
-		config.DisableSSL, 
+		config.DisableSSL,
 		config.ConnAttempts,
 	)
 }

--- a/ping.go
+++ b/ping.go
@@ -11,6 +11,11 @@ func (m HealthModule) Register(g *gin.RouterGroup) {
 	g.GET("/health", m.health)
 }
 
+func (m HealthModule) DeprecatedRegister(e *gin.Engine) {
+	e.GET("/", m.ping)
+	e.GET("/health", m.health)
+}
+
 type Ping struct {
 	Message string `json:"message"`
 }

--- a/ping.go
+++ b/ping.go
@@ -6,9 +6,9 @@ import (
 
 type HealthModule struct{}
 
-func (m HealthModule) Register(e *gin.Engine) {
-	e.GET("/", m.ping)
-	e.GET("/health", m.health)
+func (m HealthModule) Register(g *gin.RouterGroup) {
+	g.GET("/ping", m.ping)
+	g.GET("/health", m.health)
 }
 
 type Ping struct {

--- a/ping.go
+++ b/ping.go
@@ -11,8 +11,10 @@ func (m HealthModule) Register(g *gin.RouterGroup) {
 	g.GET("/health", m.health)
 }
 
-// Deprecated because they are not part of the /api group for endpoints.
-// Tentatively planned for complete removal in v6.
+// DeprecatedRegister adds API health-related endpoints to a Gin-Gonic engine.
+//
+// Deprecated: Not part of the /api group for endpoints. Tentatively planned
+// for complete removal in v6.
 func (m HealthModule) DeprecatedRegister(e *gin.Engine) {
 	e.GET("/", m.ping)
 	e.GET("/health", m.health)

--- a/ping.go
+++ b/ping.go
@@ -11,6 +11,8 @@ func (m HealthModule) Register(g *gin.RouterGroup) {
 	g.GET("/health", m.health)
 }
 
+// Deprecated because they are not part of the /api group for endpoints.
+// Tentatively planned for complete removal in v6.
 func (m HealthModule) DeprecatedRegister(e *gin.Engine) {
 	e.GET("/", m.ping)
 	e.GET("/health", m.health)


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Added `/api/health` and `/api/ping` endpoints, in preparation of removing the `/health` and `/` endpoints respectively.

## Motivation

The `/health` and `/` endpoints were not accessible through the Swagger API, as it tried to send requests to `/api/health` and `/api/ping` instead. This fixes that issue, and has all endpoints in the same group, i.e. `/api`.