### PR TITLE
Using wharf-core v1.1.0 logging throughout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added Makefile to simplify building and developing the project locally.
   (#41, #42)
 
+- Added wharf-core logging for Gin debug and errors logging. (#45)
+
+- Added wharf-core logging for GORM debug logging. (#45)
+
+- Changed version of `github.com/iver-wharf/wharf-core` from v1.0.0 to v1.1.0.
+  (#45)
+
 ## v4.1.1 (2021-07-12)
 
 - Changed version of Docker base images:

--- a/database.go
+++ b/database.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/iver-wharf/wharf-core/pkg/gormutil"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
@@ -61,10 +62,17 @@ func openDatabase(config DBConfig) (*gorm.DB, error) {
 		config.Username,
 		config.Password)
 
+	var gormConfig = gorm.Config{
+		NamingStrategy: schema.NamingStrategy{
+			SingularTable: true,
+		},
+		Logger: getLogger(config),
+	}
+
 	var db *gorm.DB
 	var err error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		db, err = gorm.Open(postgres.Open(psqlInfo), &gorm.Config{})
+		db, err = gorm.Open(postgres.Open(psqlInfo), &gormConfig)
 		if err == nil {
 			break
 		}
@@ -89,12 +97,7 @@ func openDatabase(config DBConfig) (*gorm.DB, error) {
 		config.Password,
 		config.Name)
 
-	db, err = gorm.Open(postgres.Open(psqlInfo), &gorm.Config{
-		NamingStrategy: schema.NamingStrategy{
-			SingularTable: true,
-		},
-		Logger: getLogger(config),
-	})
+	db, err = gorm.Open(postgres.Open(psqlInfo), &gormConfig)
 	if err != nil {
 		return db, err
 	}
@@ -119,7 +122,7 @@ func openDatabase(config DBConfig) (*gorm.DB, error) {
 
 func getLogger(config DBConfig) logger.Interface {
 	if config.Log {
-		return logger.Default.LogMode(logger.Info)
+		return gormutil.DefaultLogger
 	}
 	return logger.Default.LogMode(logger.Silent)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/iver-wharf/wharf-api
 go 1.16
 
 require (
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/dustin/go-broadcast v0.0.0-20171205050544-f664265f5a66
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-contrib/cors v1.3.1
@@ -13,7 +12,7 @@ require (
 	github.com/go-playground/validator/v10 v10.5.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/iver-wharf/messagebus-go v0.1.1
-	github.com/iver-wharf/wharf-core v1.0.0
+	github.com/iver-wharf/wharf-core v1.1.0
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/iver-wharf/messagebus-go v0.1.1 h1:yzDcUSgKJpd5fij7oF93NA8i2s7IzVbapwJz8veBHqo=
 github.com/iver-wharf/messagebus-go v0.1.1/go.mod h1:Jan1LPVF2P1J+dTGcwE6QBI/+kxIXHMFgEDIE58wblc=
-github.com/iver-wharf/wharf-core v1.0.0 h1:vBaGsGSMUDhTimIoaSvuX9yKKUssRxw17bbNlQ9JopY=
-github.com/iver-wharf/wharf-core v1.0.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
+github.com/iver-wharf/wharf-core v1.1.0 h1:vdjW+A8p0GBBcd1sB3vKwpN44t0dBrYfpY+B6ebSMbI=
+github.com/iver-wharf/wharf-core v1.1.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/main.go
+++ b/main.go
@@ -79,10 +79,15 @@ func main() {
 
 	r := gin.New()
 	r.Use(
-		//disable GIN logs for path "/health". Probes won't clog up logs now.
-		gin.LoggerWithWriter(gin.DefaultWriter, "/health"),
-		gin.CustomRecovery(ginutil.RecoverProblemHandle),
+		ginutil.LoggerWithConfig(ginutil.LoggerConfig{
+			//disable GIN logs for path "/health". Probes won't clog up logs now.
+			SkipPaths: []string{"/health"},
+		}),
+		ginutil.RecoverProblem,
 	)
+
+	gin.DefaultWriter = ginutil.DefaultLoggerWriter
+	gin.DefaultErrorWriter = ginutil.DefaultLoggerWriter
 
 	if config.HTTP.CORS.AllowAllOrigins {
 		log.Info().Message("Allowing all origins in CORS.")


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added missing wharf-core logging integration for DB on initialization.

- Updated wharf-core to get those new easier to read logs via iver-wharf/wharf-core#23

## Motivation

Finalizing the logging integration. Now wharf-api is properly set up to use wharf-core's logging
