### PR TITLE
Documented remaining values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added Makefile to simplify building and developing the project locally.
   (#41, #42)
 
+- Added documentation to the remaining types in the project. No more linting
+  errors! (#46)
+
 ## v4.1.1 (2021-07-12)
 
 - Changed version of Docker base images:

--- a/branch.go
+++ b/branch.go
@@ -11,11 +11,11 @@ import (
 	"gorm.io/gorm"
 )
 
-type BranchModule struct {
+type branchModule struct {
 	Database *gorm.DB
 }
 
-func (m BranchModule) Register(g *gin.RouterGroup) {
+func (m branchModule) Register(g *gin.RouterGroup) {
 	branches := g.Group("/branches")
 	{
 		branches.GET("", m.GetBranchesHandler)
@@ -34,7 +34,7 @@ func (m BranchModule) Register(g *gin.RouterGroup) {
 // @tags branch
 // @success 501 "Not Implemented"
 // @router /branches [get]
-func (m BranchModule) GetBranchesHandler(c *gin.Context) {
+func (m branchModule) GetBranchesHandler(c *gin.Context) {
 	c.Status(http.StatusNotImplemented)
 }
 
@@ -44,7 +44,7 @@ func (m BranchModule) GetBranchesHandler(c *gin.Context) {
 // @param branchid path int true "branch ID"
 // @success 501 "Not Implemented"
 // @router /branch/{branchid} [get]
-func (m BranchModule) GetBranchHandler(c *gin.Context) {
+func (m branchModule) GetBranchHandler(c *gin.Context) {
 	c.Status(http.StatusNotImplemented)
 }
 
@@ -63,7 +63,7 @@ func (m BranchModule) GetBranchHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /branch [post]
-func (m BranchModule) PostBranchHandler(c *gin.Context) {
+func (m branchModule) PostBranchHandler(c *gin.Context) {
 	var branch Branch
 	if err := c.ShouldBindJSON(&branch); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
@@ -109,7 +109,7 @@ func (m BranchModule) PostBranchHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /branches [put]
-func (m BranchModule) PutBranchesHandler(c *gin.Context) {
+func (m branchModule) PutBranchesHandler(c *gin.Context) {
 	var branches []Branch
 	if err := c.ShouldBindJSON(&branches); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
@@ -123,7 +123,7 @@ func (m BranchModule) PutBranchesHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, branches)
 }
 
-func (m BranchModule) PutBranches(branches []Branch) error {
+func (m branchModule) PutBranches(branches []Branch) error {
 	return m.Database.Transaction(func(tx *gorm.DB) error {
 		var defaultBranch Branch
 		var oldDbBranches []Branch

--- a/buildstatus.go
+++ b/buildstatus.go
@@ -2,12 +2,21 @@ package main
 
 import "strconv"
 
+// BuildStatus is an enum of different states for a build.
 type BuildStatus int
 
 const (
-	BuildScheduling = BuildStatus(iota)
+	// BuildScheduling means the build has been registered, but no code
+	// execution has begun yet. This is usually quite an ephemeral state.
+	BuildScheduling BuildStatus = iota
+	// BuildRunning means the build is executing right now. The execution
+	// engine has load in the target code paths and repositories.
 	BuildRunning
+	// BuildCompleted means the build has finished execution successfully.
 	BuildCompleted
+	// BuildFailed means that something went wrong with the build. Could be a
+	// misconfiguration in the .wharf-ci.yml file, or perhaps a scripting error
+	// in some build step.
 	BuildFailed
 )
 
@@ -33,6 +42,6 @@ var toID = map[string]BuildStatus{
 	"Failed":     BuildFailed,
 }
 
-func ParseBuildStatus(name string) BuildStatus {
+func parseBuildStatus(name string) BuildStatus {
 	return toID[name]
 }

--- a/database.go
+++ b/database.go
@@ -12,18 +12,18 @@ import (
 	"gorm.io/gorm/schema"
 )
 
-func (p *Project) MarshalJSON() ([]byte, error) {
+func (p *Project) marshalJSON() ([]byte, error) {
 	type Alias Project
 	return json.Marshal(&struct {
 		ParsedBuildDefinition interface{} `json:"build"`
 		*Alias
 	}{
-		ParsedBuildDefinition: ParseBuildDefinition(p),
+		ParsedBuildDefinition: parseBuildDefinition(p),
 		Alias:                 (*Alias)(p),
 	})
 }
 
-func ParseBuildDefinition(project *Project) interface{} {
+func parseBuildDefinition(project *Project) interface{} {
 	if project.BuildDefinition != "" {
 		var t interface{}
 		err := yaml.Unmarshal([]byte(project.BuildDefinition), &t)
@@ -41,7 +41,7 @@ func ParseBuildDefinition(project *Project) interface{} {
 	return nil
 }
 
-func (b *Build) MarshalJSON() ([]byte, error) {
+func (b *Build) marshalJSON() ([]byte, error) {
 	type Alias Build
 	return json.Marshal(&struct {
 		Status string `json:"status"`

--- a/database_models.go
+++ b/database_models.go
@@ -19,6 +19,9 @@ const (
 	providerFieldTokenID   = "TokenID"
 )
 
+// Provider holds metadata about a connection to a remote provider. Some of
+// importance are the URL field of where to find the remote, and the token field
+// used to authenticate.
 type Provider struct {
 	ProviderID uint   `gorm:"primaryKey" json:"providerId"`
 	Name       string `gorm:"size:20;not null" json:"name" enum:"azuredevops,gitlab,github"`
@@ -33,6 +36,7 @@ const (
 	tokenFieldUserName = "UserName"
 )
 
+// Token holds credentials for a remote provider.
 type Token struct {
 	TokenID  uint   `gorm:"primaryKey" json:"tokenId"`
 	Token    string `gorm:"size:500; not null" json:"token" format:"password"`
@@ -49,6 +53,9 @@ const (
 	projectAssocToken     = "Token"
 )
 
+// Project holds data about an imported project. A lot of the data is expected
+// to be populated with data from the remote provider, such as the description
+// and avatar.
 type Project struct {
 	ProjectID       uint      `gorm:"primaryKey" json:"projectId"`
 	Name            string    `gorm:"size:500;not null" json:"name"`
@@ -71,6 +78,8 @@ const (
 	branchFieldTokenID   = "TokenID"
 )
 
+// Branch is a single branch in the VCS that can be targeted during builds.
+// For example a Git branch.
 type Branch struct {
 	BranchID  uint     `gorm:"primaryKey" json:"branchId"`
 	ProjectID uint     `gorm:"not null;index:branch_idx_project_id" json:"projectId"`
@@ -98,6 +107,8 @@ var buildJSONToColumns = map[string]string{
 	"isInvalid":   "is_invalid",
 }
 
+// Build holds data about the state of a build. Which parameters was used to
+// start it, what status it holds, et.al.
 type Build struct {
 	BuildID     uint         `gorm:"primaryKey" json:"buildId"`
 	StatusID    BuildStatus  `gorm:"not null" json:"statusId"`
@@ -113,6 +124,7 @@ type Build struct {
 	IsInvalid   bool         `gorm:"not null;default:false" json:"isInvalid"`
 }
 
+// BuildParam holds the name and value of an input parameter fed into a build.
 type BuildParam struct {
 	BuildParamID uint   `gorm:"primaryKey" json:"-"`
 	BuildID      uint   `gorm:"not null;index:buildparam_idx_build_id" json:"buildId"`
@@ -121,6 +133,7 @@ type BuildParam struct {
 	Value        string `gorm:"nullable" json:"value"`
 }
 
+// Log is a single logged line for a build.
 type Log struct {
 	LogID     uint      `gorm:"primaryKey" json:"logId"`
 	BuildID   uint      `gorm:"not null;index:log_idx_build_id" json:"buildId"`
@@ -129,6 +142,7 @@ type Log struct {
 	Timestamp time.Time `gorm:"not null" json:"timestamp" format:"date-time"`
 }
 
+// Param holds the definition of a input parameter for a project.
 type Param struct {
 	ParamID      int    `gorm:"primaryKey" json:"id"`
 	Name         string `gorm:"not null" json:"name"`
@@ -142,6 +156,8 @@ const (
 	artifactColumnFileName   = "file_name"
 )
 
+// Artifact holds the binary data as well as metadata about that binary such as
+// the file name and which build it belongs to.
 type Artifact struct {
 	ArtifactID uint   `gorm:"primaryKey" json:"artifactId"`
 	BuildID    uint   `gorm:"not null;index:param_idx_build_id" json:"buildId"`

--- a/database_models.go
+++ b/database_models.go
@@ -142,7 +142,7 @@ type Log struct {
 	Timestamp time.Time `gorm:"not null" json:"timestamp" format:"date-time"`
 }
 
-// Param holds the definition of a input parameter for a project.
+// Param holds the definition of an input parameter for a project.
 type Param struct {
 	ParamID      int    `gorm:"primaryKey" json:"id"`
 	Name         string `gorm:"not null" json:"name"`

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 		r.Use(cors.New(corsConfig))
 	}
 
-	HealthModule{}.Register(r)
+	healthModule{}.Register(r)
 
 	setupBasicAuth(r, config)
 
@@ -115,12 +115,12 @@ func main() {
 		}()
 	}
 
-	modules := []HTTPModule{
-		ProjectModule{Database: db, MessageQueue: mq, Config: &config},
-		BuildModule{Database: db, MessageQueue: mq},
-		TokenModule{Database: db},
-		BranchModule{Database: db},
-		ProviderModule{Database: db}}
+	modules := []httpModule{
+		projectModule{Database: db, MessageQueue: mq, Config: &config},
+		buildModule{Database: db, MessageQueue: mq},
+		tokenModule{Database: db},
+		branchModule{Database: db},
+		providerModule{Database: db}}
 
 	api := r.Group("/api")
 	for _, module := range modules {

--- a/module.go
+++ b/module.go
@@ -4,6 +4,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type HTTPModule interface {
+type httpModule interface {
 	Register(*gin.RouterGroup)
 }

--- a/ping.go
+++ b/ping.go
@@ -4,13 +4,14 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type HealthModule struct{}
+type healthModule struct{}
 
-func (m HealthModule) Register(e *gin.Engine) {
+func (m healthModule) Register(e *gin.Engine) {
 	e.GET("/", m.ping)
 	e.GET("/health", m.health)
 }
 
+// Ping pongs.
 type Ping struct {
 	Message string `json:"message"`
 }
@@ -22,10 +23,12 @@ type Ping struct {
 // @produce json
 // @success 200 {object} Ping
 // @router /ping [get]
-func (m HealthModule) ping(c *gin.Context) {
+func (m healthModule) ping(c *gin.Context) {
 	c.JSON(200, Ping{Message: "pong"})
 }
 
+// HealthStatus holds a human-readable string stating the health of the API and
+// its integrations, as well as a boolean for easy machine-readability.
 type HealthStatus struct {
 	Message   string `example:"API is healthy." json:"message"`
 	IsHealthy bool   `example:"true" json:"isHealthy"`
@@ -38,6 +41,6 @@ type HealthStatus struct {
 // @produce json
 // @success 200 {object} HealthStatus
 // @router /health [get]
-func (m HealthModule) health(c *gin.Context) {
+func (m healthModule) health(c *gin.Context) {
 	c.JSON(200, HealthStatus{Message: "API is healthy.", IsHealthy: true})
 }

--- a/pkg/orderby/direction.go
+++ b/pkg/orderby/direction.go
@@ -4,10 +4,15 @@ import (
 	"fmt"
 )
 
+// Direction tells if an ordering is in ascending order or descending order.
 type Direction byte
 
 const (
+	// Asc means "ascending sorting order". For example the numbers 1, 2, 3, 4
+	// are in ascending order, as well as the letters A, B, C, D.
 	Asc Direction = iota + 1
+	// Desc means "descending sorting order". For example the numbers 4, 3, 2, 1
+	// are in descending order, as well as the letters D, C, B, A.
 	Desc
 )
 

--- a/pkg/orderby/orderby.go
+++ b/pkg/orderby/orderby.go
@@ -8,6 +8,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// OrderBy specifies a column or field to be sorted and its sorting direction.
 type OrderBy struct {
 	Column    string
 	Direction Direction

--- a/project.go
+++ b/project.go
@@ -29,7 +29,7 @@ type projectModule struct {
 	Config       *Config
 }
 
-// PaginatedBuilds is a list of builds as well as an explicit total cound field.
+// PaginatedBuilds is a list of builds as well as an explicit total count field.
 type PaginatedBuilds struct {
 	Builds     *[]Build `json:"builds"`
 	TotalCount int64    `json:"totalCount"`

--- a/project_test.go
+++ b/project_test.go
@@ -56,7 +56,7 @@ inputs:
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := ParseBuildParams(tc.buildID, tc.buildDef, tc.params)
+			got, err := parseBuildParams(tc.buildID, tc.buildDef, tc.params)
 			require.Nil(t, err)
 			assert.Equal(t, len(tc.want), len(got))
 

--- a/token.go
+++ b/token.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 
 	"net/http"
@@ -11,11 +12,11 @@ import (
 	"gorm.io/gorm"
 )
 
-type TokenModule struct {
+type tokenModule struct {
 	Database *gorm.DB
 }
 
-func (m TokenModule) Register(g *gin.RouterGroup) {
+func (m tokenModule) Register(g *gin.RouterGroup) {
 	tokens := g.Group("/tokens")
 	{
 		tokens.GET("", m.getTokensHandler)
@@ -37,7 +38,7 @@ func (m TokenModule) Register(g *gin.RouterGroup) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /tokens [get]
-func (m TokenModule) getTokensHandler(c *gin.Context) {
+func (m tokenModule) getTokensHandler(c *gin.Context) {
 
 	var tokens []Token
 	err := m.Database.Limit(100).Find(&tokens).Error
@@ -58,7 +59,7 @@ func (m TokenModule) getTokensHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /token/{tokenid} [get]
-func (m TokenModule) getTokenHandler(c *gin.Context) {
+func (m tokenModule) getTokenHandler(c *gin.Context) {
 	tokenID, ok := ginutil.ParseParamUint(c, "tokenid")
 	if !ok {
 		return
@@ -92,7 +93,7 @@ func (m TokenModule) getTokenHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /tokens/search [post]
-func (m TokenModule) postSearchTokenHandler(c *gin.Context) {
+func (m tokenModule) postSearchTokenHandler(c *gin.Context) {
 	var token Token
 	if err := c.ShouldBindJSON(&token); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
@@ -115,6 +116,8 @@ func (m TokenModule) postSearchTokenHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, tokens)
 }
 
+// TokenWithProviderID is an extended token model that also contains the ID of
+// an associated provider.
 type TokenWithProviderID struct {
 	Token
 	ProviderID uint `json:"providerId"`
@@ -133,7 +136,7 @@ type TokenWithProviderID struct {
 // @failure 404 {object} problem.Response "Referenced provider not found"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /token [post]
-func (m TokenModule) postTokenHandler(c *gin.Context) {
+func (m tokenModule) postTokenHandler(c *gin.Context) {
 	var (
 		tokenWithProviderID TokenWithProviderID
 		token               *Token
@@ -191,7 +194,7 @@ func (m TokenModule) postTokenHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /token [put]
-func (m TokenModule) putTokenHandler(c *gin.Context) {
+func (m tokenModule) putTokenHandler(c *gin.Context) {
 	var inputToken Token
 	if err := c.ShouldBindJSON(&inputToken); err != nil {
 		ginutil.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed a lot of types & functions from exported to unexported.

- Documented the remaining exported types that needs to be exported, such as JSON responses and DB models.

## Motivation

We start growing error fatigue due to the existing errors. Broken window principle applies here.

If we have properly commented everything, it'll be easier to see how we should keep it, and it's be less insentive to just ignore the linting errors.
