### PR TITLE
Moved httputils & updated its logging

### DIFF
--- a/internal/httputils/httpclient.go
+++ b/internal/httputils/httpclient.go
@@ -10,7 +10,7 @@ import (
 	"github.com/iver-wharf/wharf-core/pkg/logger"
 )
 
-var log = logger.New()
+var log = logger.NewScoped("HTTPUTILS")
 
 // NewClientWithCerts creates a fresh net/http.Client populated with some
 // root CA certificates from file.
@@ -23,9 +23,9 @@ func NewClientWithCerts(localCertFile string) (*http.Client, error) {
 	// Get the SystemCertPool, continue with an empty pool on error
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()
-		log.Info().Message("Using empty cert pool.")
+		log.Debug().Message("Using empty cert pool.")
 	} else {
-		log.Info().Message("Using system cert pool.")
+		log.Debug().Message("Using system's cert pool.")
 	}
 
 	// Read in the cert file
@@ -34,12 +34,11 @@ func NewClientWithCerts(localCertFile string) (*http.Client, error) {
 		return nil, fmt.Errorf("failed to append %q to RootCAs: %v", localCertFile, err)
 	}
 
-	log.Info().WithString("certsFile", localCertFile).Message("Loaded certs from file.")
+	log.Debug().WithString("file", localCertFile).Message("Loaded certs.")
 
 	// Append our cert to the system pool
 	if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-		log.Warn().WithString("certsFile", localCertFile).
-			Message("No new certs appended. Using system certs only.")
+		log.Debug().Message("No certs appended, using system certs only.")
 	}
 
 	// Trust the augmented cert pool in our client

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/iver-wharf/wharf-api/docs"
-	"github.com/iver-wharf/wharf-api/pkg/httputils"
+	"github.com/iver-wharf/wharf-api/internal/httputils"
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
 )


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Moved httputils to have it placed in the same location as in the provider repos. That is, in the internals dir

## Motivation

To make things consistent
