### PR TITLE
Swaggo/swag v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   `/api/health` respectively, so they are aligned with the current Swagger
   documentation. (#44)
 
+- Changed version of `github.com/swaggo/swag/cmd/swag` from v1.7.0 to v1.7.1 in
+  Dockerfile and Makefile. (#48)
+
 ## v4.1.1 (2021-07-12)
 
 - Changed version of Docker base images:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.16.5 AS build
 WORKDIR /src
-RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
+RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.1
 COPY go.mod go.sum ./
 RUN go mod download
 

--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,5 @@ swag:
 	swag init --parseDependency --parseDepth 1
 
 deps:
-	cd .. && go get -u github.com/swaggo/swag
+	cd .. && go get -u github.com/swaggo/swag/cmd/swag@v1.7.1
 	go mod download

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/iver-wharf/wharf-api
 go 1.16
 
 require (
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/dustin/go-broadcast v0.0.0-20171205050544-f664265f5a66
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-contrib/cors v1.3.1


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Swaggo v1.7.1, thereby eliminating the dependecy on the alecthomas/template package.

## Motivation

Stay up-to-date
