### PR TITLE
Fixed docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY . .
 ARG BUILD_VERSION="local docker"
 ARG BUILD_GIT_COMMIT="HEAD"
 ARG BUILD_REF="0"
+ARG BUILD_DATE=""
 RUN deploy/update-version.sh version.yaml \
 		&& make swag \
 		&& CGO_ENABLED=0 go build -o main \


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- BUILD_DATE was not used when building the binary, but instead a new value was calculated. This fixes that so the value will be identical to the one used in the Docker labels

## Motivation

Fixing inconsistencies
