### PR TITLE
Fixed project & build JSON marshal regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   (#45)
 
 - Added documentation to the remaining types in the project. No more linting
-  errors! (#46)
+  errors! (#46, #54)
 
 - Added new endpoints `/api/ping` and `/api/health`. (#44)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed logging on "attempting to reach database" during initialization from
   "ERROR" to "WARN", and rephrased it a little. (#50)
 
+- Fixed so failed parsing of build status in the `PUT /build/{buildid}` and
+  `POST /build/{buildid}/log` endpoints not silently ignore it and fallback to
+  "Scheduling", but instead respond with appropriate problem responses. (#54)
+
 ## v4.1.1 (2021-07-12)
 
 - Changed version of Docker base images:

--- a/buildstatus.go
+++ b/buildstatus.go
@@ -42,6 +42,7 @@ var toID = map[string]BuildStatus{
 	"Failed":     BuildFailed,
 }
 
-func parseBuildStatus(name string) BuildStatus {
-	return toID[name]
+func parseBuildStatus(name string) (status BuildStatus, ok bool) {
+	status, ok = toID[name]
+	return
 }

--- a/database.go
+++ b/database.go
@@ -1,57 +1,15 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/iver-wharf/wharf-core/pkg/gormutil"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 	"gorm.io/gorm/schema"
 )
-
-func (p *Project) marshalJSON() ([]byte, error) {
-	type Alias Project
-	return json.Marshal(&struct {
-		ParsedBuildDefinition interface{} `json:"build"`
-		*Alias
-	}{
-		ParsedBuildDefinition: parseBuildDefinition(p),
-		Alias:                 (*Alias)(p),
-	})
-}
-
-func parseBuildDefinition(project *Project) interface{} {
-	if project.BuildDefinition != "" {
-		var t interface{}
-		err := yaml.Unmarshal([]byte(project.BuildDefinition), &t)
-		if err != nil {
-			log.Error().
-				WithError(err).
-				WithUint("project", project.ProjectID).
-				Message("Failed to parse build-definition.")
-			return nil
-		}
-
-		return convert(t)
-	}
-
-	return nil
-}
-
-func (b *Build) marshalJSON() ([]byte, error) {
-	type Alias Build
-	return json.Marshal(&struct {
-		Status string `json:"status"`
-		*Alias
-	}{
-		Status: b.StatusID.String(),
-		Alias:  (*Alias)(b),
-	})
-}
 
 func openDatabase(config DBConfig) (*gorm.DB, error) {
 	const retryDelay = 2 * time.Second

--- a/database_models.go
+++ b/database_models.go
@@ -69,6 +69,8 @@ type Project struct {
 	BuildDefinition string    `sql:"type:text" json:"buildDefinition"`
 	Branches        []Branch  `gorm:"foreignKey:ProjectID" json:"branches"`
 	GitURL          string    `gorm:"nullable;default:NULL" json:"gitUrl"`
+	// ParsedBuildDefinition is populated when marshalled via MarshalJSON
+	ParsedBuildDefinition interface{} `gorm:"-" json:"build"`
 }
 
 const (
@@ -122,6 +124,8 @@ type Build struct {
 	Stage       string       `gorm:"size:40;default:'';not null" json:"stage"`
 	Params      []BuildParam `gorm:"foreignKey:BuildID" json:"params"`
 	IsInvalid   bool         `gorm:"not null;default:false" json:"isInvalid"`
+	// Status is populated when marshalled via MarshalJSON
+	Status string `gorm:"-" json:"status"`
 }
 
 // BuildParam holds the name and value of an input parameter fed into a build.

--- a/database_models_json.go
+++ b/database_models_json.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/ghodss/yaml"
+)
+
+// MarshalJSON implements Marshaler interface from encoding/json.
+func (p *Project) MarshalJSON() ([]byte, error) {
+	p.ParsedBuildDefinition = p.parseBuildDefinition()
+	type antiInfiniteLoop Project
+	return json.Marshal((*antiInfiniteLoop)(p))
+}
+
+func (p *Project) parseBuildDefinition() interface{} {
+	if p.BuildDefinition != "" {
+		var t interface{}
+		err := yaml.Unmarshal([]byte(p.BuildDefinition), &t)
+		if err != nil {
+			log.Error().
+				WithError(err).
+				WithUint("project", p.ProjectID).
+				Message("Failed to parse build-definition.")
+			return nil
+		}
+		return unmarshalledYAMLToMarshallableJSON(t)
+	}
+	return nil
+}
+
+// MarshalJSON implements Marshaler interface from encoding/json.
+func (b *Build) MarshalJSON() ([]byte, error) {
+	b.Status = b.StatusID.String()
+	type antiInfiniteLoop Build
+	return json.Marshal((*antiInfiniteLoop)(b))
+}

--- a/database_models_json.go
+++ b/database_models_json.go
@@ -7,13 +7,13 @@ import (
 )
 
 // MarshalJSON implements Marshaler interface from encoding/json.
-func (p *Project) MarshalJSON() ([]byte, error) {
+func (p Project) MarshalJSON() ([]byte, error) {
 	p.ParsedBuildDefinition = p.parseBuildDefinition()
 	type antiInfiniteLoop Project
-	return json.Marshal((*antiInfiniteLoop)(p))
+	return json.Marshal((antiInfiniteLoop)(p))
 }
 
-func (p *Project) parseBuildDefinition() interface{} {
+func (p Project) parseBuildDefinition() interface{} {
 	if p.BuildDefinition != "" {
 		var t interface{}
 		err := yaml.Unmarshal([]byte(p.BuildDefinition), &t)
@@ -24,14 +24,14 @@ func (p *Project) parseBuildDefinition() interface{} {
 				Message("Failed to parse build-definition.")
 			return nil
 		}
-		return unmarshalledYAMLToMarshallableJSON(t)
+		return t
 	}
 	return nil
 }
 
 // MarshalJSON implements Marshaler interface from encoding/json.
-func (b *Build) MarshalJSON() ([]byte, error) {
+func (b Build) MarshalJSON() ([]byte, error) {
 	b.Status = b.StatusID.String()
 	type antiInfiniteLoop Build
-	return json.Marshal((*antiInfiniteLoop)(b))
+	return json.Marshal((antiInfiniteLoop)(b))
 }

--- a/database_models_json_test.go
+++ b/database_models_json_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectBuildDefMarshalJSON(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		inputProject interface{}
+		wantBuildDef interface{}
+	}{
+		{
+			name:         "no build def",
+			inputProject: Project{},
+			wantBuildDef: nil,
+		},
+		{
+			name:         "with build def/value",
+			inputProject: Project{BuildDefinition: "myStage: moo"},
+			wantBuildDef: map[string]interface{}{
+				"myStage": "moo",
+			},
+		},
+		{
+			name:         "with build def/ref",
+			inputProject: &Project{BuildDefinition: "myStage: moo"},
+			wantBuildDef: map[string]interface{}{
+				"myStage": "moo",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.inputProject)
+			require.NoError(t, err)
+
+			var projectMap map[string]interface{}
+			err = json.Unmarshal(b, &projectMap)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantBuildDef, projectMap["build"])
+		})
+	}
+}
+
+func TestBuildStatusMarshalJSON(t *testing.T) {
+	var testCases = []struct {
+		name       string
+		inputBuild interface{}
+		wantStatus string
+	}{
+		{
+			name:       "invalid status ID",
+			inputBuild: Build{StatusID: -15},
+			wantStatus: "-15",
+		},
+		{
+			name:       "zero status ID",
+			inputBuild: Build{StatusID: 0},
+			wantStatus: "Scheduling",
+		},
+		{
+			name:       "non-zero status ID/value",
+			inputBuild: Build{StatusID: BuildRunning},
+			wantStatus: "Running",
+		},
+		{
+			name:       "non-zero status ID/ref",
+			inputBuild: &Build{StatusID: BuildRunning},
+			wantStatus: "Running",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.inputBuild)
+			require.NoError(t, err)
+
+			var buildMap map[string]interface{}
+			err = json.Unmarshal(b, &buildMap)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantStatus, buildMap["status"])
+		})
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -14,22 +14,6 @@ func contains(items []string, value string) bool {
 	return false
 }
 
-func unmarshalledYAMLToMarshallableJSON(i interface{}) interface{} {
-	switch x := i.(type) {
-	case map[interface{}]interface{}:
-		m2 := map[string]interface{}{}
-		for k, v := range x {
-			m2[k.(string)] = unmarshalledYAMLToMarshallableJSON(v)
-		}
-		return m2
-	case []interface{}:
-		for i, v := range x {
-			x[i] = unmarshalledYAMLToMarshallableJSON(v)
-		}
-	}
-	return i
-}
-
 func getProjectGroupFromGitURL(gitURL string, projectName string) string {
 	pattern := regexp.MustCompile(`((git@[\w\.]+)):(?P<projectPath>[\w\.@\:/\-~]+)(\.git)(/)?`)
 	if !pattern.MatchString(gitURL) {

--- a/utils.go
+++ b/utils.go
@@ -14,17 +14,17 @@ func contains(items []string, value string) bool {
 	return false
 }
 
-func convert(i interface{}) interface{} {
+func unmarshalledYAMLToMarshallableJSON(i interface{}) interface{} {
 	switch x := i.(type) {
 	case map[interface{}]interface{}:
 		m2 := map[string]interface{}{}
 		for k, v := range x {
-			m2[k.(string)] = convert(v)
+			m2[k.(string)] = unmarshalledYAMLToMarshallableJSON(v)
 		}
 		return m2
 	case []interface{}:
 		for i, v := range x {
-			x[i] = convert(v)
+			x[i] = unmarshalledYAMLToMarshallableJSON(v)
 		}
 	}
 	return i

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,53 +1,10 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-func TestConvert(t *testing.T) {
-	type testCase struct {
-		name     string
-		buildDef string
-		wantJSON string
-		wantYML  string
-	}
-
-	tests := []testCase{
-		{
-			name:     "Simple build definition convert test",
-			buildDef: "build:\n  foo:\n    docker:\n      file: \"test.txt\"",
-			wantJSON: "{\"build\":{\"foo\":{\"docker\":{\"file\":\"test.txt\"}}}}",
-			wantYML:  "map[build:map[foo:map[docker:map[file:test.txt]]]]",
-		},
-		{
-			name:     "Build definition convert test",
-			buildDef: "build:\n  foo.service:\n    docker:\n      file: src/Foo.Service/Dockerfile\n      tag: ${GIT_COMMIT},latest\n  foo.web:\n    docker:\n      file: src/Foo.Web/Dockerfile\n      tag: ${GIT_COMMIT},latest\n\ndeploy:\n  service:\n    helm:\n      name: foo-service\n      namespace: stage\n      chart: web-app\n      repo: ${CHART_REPO}/library\n      files: [\"deploy/stage-service.yml\"]\n\n  web:\n    helm:\n      name: foo-web\n      namespace: stage\n      chart: web-app\n      repo: ${CHART_REPO}/library\n      files: [\"deploy/stage-web.yml\"]\n\n  elastic:\n    kubectl:\n      namespace: stage\n      file: deploy/elastic.yml\n",
-			wantJSON: "{\"build\":{\"foo.service\":{\"docker\":{\"file\":\"src/Foo.Service/Dockerfile\",\"tag\":\"${GIT_COMMIT},latest\"}},\"foo.web\":{\"docker\":{\"file\":\"src/Foo.Web/Dockerfile\",\"tag\":\"${GIT_COMMIT},latest\"}}},\"deploy\":{\"elastic\":{\"kubectl\":{\"file\":\"deploy/elastic.yml\",\"namespace\":\"stage\"}},\"service\":{\"helm\":{\"chart\":\"web-app\",\"files\":[\"deploy/stage-service.yml\"],\"name\":\"foo-service\",\"namespace\":\"stage\",\"repo\":\"${CHART_REPO}/library\"}},\"web\":{\"helm\":{\"chart\":\"web-app\",\"files\":[\"deploy/stage-web.yml\"],\"name\":\"foo-web\",\"namespace\":\"stage\",\"repo\":\"${CHART_REPO}/library\"}}}}",
-			wantYML:  "map[build:map[foo.service:map[docker:map[file:src/Foo.Service/Dockerfile tag:${GIT_COMMIT},latest]] foo.web:map[docker:map[file:src/Foo.Web/Dockerfile tag:${GIT_COMMIT},latest]]] deploy:map[elastic:map[kubectl:map[file:deploy/elastic.yml namespace:stage]] service:map[helm:map[chart:web-app files:[deploy/stage-service.yml] name:foo-service namespace:stage repo:${CHART_REPO}/library]] web:map[helm:map[chart:web-app files:[deploy/stage-web.yml] name:foo-web namespace:stage repo:${CHART_REPO}/library]]]]",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var ymlInterface interface{}
-			err := yaml.Unmarshal([]byte(tc.buildDef), &ymlInterface)
-			require.Nil(t, err)
-			assert.Equal(t, tc.wantYML, fmt.Sprint(ymlInterface))
-
-			ymlToObj := unmarshalledYAMLToMarshallableJSON(ymlInterface)
-
-			b, err := json.Marshal(ymlToObj)
-			require.Nil(t, err)
-			assert.Equal(t, tc.wantJSON, string(b))
-		})
-	}
-}
 
 func TestGetProjectGroupFromGitURL(t *testing.T) {
 	type testCase struct {

--- a/utils_test.go
+++ b/utils_test.go
@@ -40,7 +40,7 @@ func TestConvert(t *testing.T) {
 			require.Nil(t, err)
 			assert.Equal(t, tc.wantYML, fmt.Sprint(ymlInterface))
 
-			ymlToObj := convert(ymlInterface)
+			ymlToObj := unmarshalledYAMLToMarshallableJSON(ymlInterface)
 
 			b, err := json.Marshal(ymlToObj)
 			require.Nil(t, err)


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed regression introduced in #46 where `Project.MarshalJSON` and `Build.MarshalJSON` were renamed, unknowing that it broke the Go interface [`Marshaler`](https://pkg.go.dev/encoding/json#Marshaler) from the `encoding/json` package.

  This lead to the `GET /projects` and `GET /project/{projectid}` to not have their parsed build definitions, that are needed in the wharf-web.

- Fixed bug where if it silently ignored failing status parsing

## Motivation

This still regards unreleased changes, so I've not added a dedicated release note for it.

The refactoring was made to try and make it clearer that this marshalling is being done, as @Alexamakans spent hours trying to figure out why the `build` property was missing from the HTTP responses. Hopefully it's made clearer now and could save future devs some hours of debugging.

The best would be to have different structs for database and HTTP responses, but I'm delaying that for the iver-wharf/rfcs#16 implementation as it plans on tackling this.
