### PR TITLE
Removed constraint of "cannot change group"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed logging on "attempting to reach database" during initialization from
   "ERROR" to "WARN", and rephrased it a little. (#50)
 
+- Removed constraint that project groups cannot be changed in the
+  `PUT /project` endpoint. This deprecates the problem
+  `/prob/api/project/cannot-change-group`. (#55)
+
 ## v4.1.1 (2021-07-12)
 
 - Changed version of Docker base images:

--- a/project.go
+++ b/project.go
@@ -320,7 +320,7 @@ func (m projectModule) deleteProjectHandler(c *gin.Context) {
 // @produce json
 // @param project body Project _ "project object"
 // @success 200 {object} Project
-// @failure 400 {object} problem.Response "Bad request, such as invalid body JSON or when altering group"
+// @failure 400 {object} problem.Response "Bad request, such as invalid body JSON"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 404 {object} problem.Response "Project to update was not found"
 // @failure 502 {object} problem.Response "Database is unreachable"
@@ -360,18 +360,6 @@ func (m projectModule) putProjectHandler(c *gin.Context) {
 				project.Name, project.GroupName))
 			return
 		}
-	}
-
-	if existingProject.GroupName != project.GroupName {
-		ginutil.WriteProblem(c, problem.Response{
-			Type:  "/prob/api/project/cannot-change-group",
-			Title: "Project group cannot be changed.",
-			Detail: fmt.Sprintf(
-				"Changing the group of a project is prohibited. The client tried to change group on project %d from %q to %q.",
-				project.ProjectID, existingProject.GroupName, project.GroupName),
-			Status: http.StatusBadRequest,
-		})
-		return
 	}
 
 	project.ProjectID = existingProject.ProjectID


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Removed `cannot-change-group` constraint from `PUT /project`

## Motivation

The constraint is somewhat arbitrary and lacks motivation.

Also, for the migrations needed for https://github.com/iver-wharf/rfcs/pull/17 then this constraint would've been in the way.
