### PR TITLE
Rely on Docker images latest patch version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   `PUT /project` endpoint. This deprecates the problem
   `/prob/api/project/cannot-change-group`. (#55)
 
+- Changed version of Docker base images, relying on "latest" patch version:
+
+  - Alpine: 3.14.0 -> 3.14 (#59)
+  - Golang: 1.16.5 -> 1.16 (#59)
+
 ## v4.1.1 (2021-07-12)
 
 - Changed version of Docker base images:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5 AS build
+FROM golang:1.16 AS build
 WORKDIR /src
 RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.1
 COPY go.mod go.sum ./
@@ -14,7 +14,7 @@ RUN deploy/update-version.sh version.yaml \
 		&& CGO_ENABLED=0 go build -o main \
 		&& make test
 
-FROM alpine:3.14.0 AS final
+FROM alpine:3.14 AS final
 RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 COPY --from=build /src/main ./


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Removed the patch version from Docker base images, as that will use the latest patch version instead.

## Motivation

Leads to fewer vulnerabilities to stay on "latest", while still not getting failing builds due to breaking changes in version bumps.

This also fixes the following vulnerabilities:

```console
$ trivy i -i v4.2.0-rc.1.tar
2021-09-09T08:54:56.799+0200	INFO	Detected OS: alpine
2021-09-09T08:54:56.799+0200	INFO	Detecting Alpine vulnerabilities...
2021-09-09T08:54:56.799+0200	INFO	Number of language-specific files: 1
2021-09-09T08:54:56.799+0200	INFO	Detecting gobinary vulnerabilities...

v4.2.0-rc.1.tar (alpine 3.14.0)
===============================
Total: 5 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 2, CRITICAL: 3)

+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| apk-tools    | CVE-2021-36159   | CRITICAL | 2.12.5-r1         | 2.12.6-r0     | libfetch before 2021-07-26, as        |
|              |                  |          |                   |               | used in apk-tools, xbps, and          |
|              |                  |          |                   |               | other products, mishandles...         |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-36159 |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| libcrypto1.1 | CVE-2021-3711    |          | 1.1.1k-r0         | 1.1.1l-r0     | openssl: SM2 Decryption               |
|              |                  |          |                   |               | Buffer Overflow                       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3711  |
+              +------------------+----------+                   +               +---------------------------------------+
|              | CVE-2021-3712    | HIGH     |                   |               | openssl: Read buffer overruns         |
|              |                  |          |                   |               | processing ASN.1 strings              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3712  |
+--------------+------------------+----------+                   +               +---------------------------------------+
| libssl1.1    | CVE-2021-3711    | CRITICAL |                   |               | openssl: SM2 Decryption               |
|              |                  |          |                   |               | Buffer Overflow                       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3711  |
+              +------------------+----------+                   +               +---------------------------------------+
|              | CVE-2021-3712    | HIGH     |                   |               | openssl: Read buffer overruns         |
|              |                  |          |                   |               | processing ASN.1 strings              |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3712  |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+

app/main (gobinary)
===================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```
