### PR TITLE
Release v4.2.0 (with fixed date)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v4.2.0 (2021-09-09)
+## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.
   `"Europe/Stockholm"`) through the tzdata package. (#40)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

Same as for #58

## Motivation

I forgot to update the date in the CHANGELOG.md before merging. Again.

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
