### PR TITLE
Fixed so gin logger intration is setup before it's used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v4.2.1 (WIP)
+
+- Fixed where wharf-core logging for Gin debug and error messages were set up
+  after they were initially used, leading to a mix of wharf-core and Gin
+  formatted logs. (#63)
+
 ## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.

--- a/main.go
+++ b/main.go
@@ -94,6 +94,9 @@ func main() {
 		}()
 	}
 
+	gin.DefaultWriter = ginutil.DefaultLoggerWriter
+	gin.DefaultErrorWriter = ginutil.DefaultLoggerWriter
+
 	r := gin.New()
 	r.Use(
 		ginutil.LoggerWithConfig(ginutil.LoggerConfig{
@@ -102,9 +105,6 @@ func main() {
 		}),
 		ginutil.RecoverProblem,
 	)
-
-	gin.DefaultWriter = ginutil.DefaultLoggerWriter
-	gin.DefaultErrorWriter = ginutil.DefaultLoggerWriter
 
 	if config.HTTP.CORS.AllowAllOrigins {
 		log.Info().Message("Allowing all origins in CORS.")


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Moved `gin.DefaultWriter` assignment to before `gin.New()` is called.

## Motivation

`gin.New()` can do some logging, such as the following log message:

```log
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)
```

This fixes that so it uses wharf-core logger for that as well.
