### PR TITLE
Fixed cannot delete projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Fixed where wharf-core logging for Gin debug and error messages were set up
   after they were initially used, leading to a mix of wharf-core and Gin
-  formatted logs. (#63
+  formatted logs. (#63)
 
 ## v4.2.0 (2021-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v4.2.1 (WIP)
 
-- Fixed bug not being able to delete projects without first deleting all child
+- Fixed bug where unable to delete a Project without first deleting all child
   objects. (#64)
 
 ## v4.2.0 (2021-09-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v4.2.1 (WIP)
 
-- Fixed not being able to delete projects without first deleting all child
-  objects. (#?)
+- Fixed bug not being able to delete projects without first deleting all child
+  objects. (#64)
 
 ## v4.2.0 (2021-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v4.2.1 (WIP)
+
+- Fixed not being able to delete projects without first deleting all child
+  objects. (#?)
+
 ## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.

--- a/database_models.go
+++ b/database_models.go
@@ -85,7 +85,7 @@ const (
 type Branch struct {
 	BranchID  uint     `gorm:"primaryKey" json:"branchId"`
 	ProjectID uint     `gorm:"not null;index:branch_idx_project_id" json:"projectId"`
-	Project   *Project `gorm:"foreignKey:ProjectID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT" json:"-"`
+	Project   *Project `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
 	Name      string   `gorm:"not null" json:"name"`
 	Default   bool     `gorm:"not null" json:"default"`
 	TokenID   uint     `gorm:"nullable;default:NULL;index:branch_idx_token_id" json:"tokenId"`
@@ -115,7 +115,7 @@ type Build struct {
 	BuildID     uint         `gorm:"primaryKey" json:"buildId"`
 	StatusID    BuildStatus  `gorm:"not null" json:"statusId"`
 	ProjectID   uint         `gorm:"not null;index:build_idx_project_id" json:"projectId"`
-	Project     *Project     `gorm:"foreignKey:ProjectID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT" json:"-"`
+	Project     *Project     `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
 	ScheduledOn *time.Time   `gorm:"nullable;default:NULL" json:"scheduledOn" format:"date-time"`
 	StartedOn   *time.Time   `gorm:"nullable;default:NULL" json:"startedOn" format:"date-time"`
 	CompletedOn *time.Time   `gorm:"nullable;default:NULL" json:"finishedOn" format:"date-time"`
@@ -132,7 +132,7 @@ type Build struct {
 type BuildParam struct {
 	BuildParamID uint   `gorm:"primaryKey" json:"-"`
 	BuildID      uint   `gorm:"not null;index:buildparam_idx_build_id" json:"buildId"`
-	Build        *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT" json:"-"`
+	Build        *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
 	Name         string `gorm:"not null" json:"name"`
 	Value        string `gorm:"nullable" json:"value"`
 }
@@ -141,7 +141,7 @@ type BuildParam struct {
 type Log struct {
 	LogID     uint      `gorm:"primaryKey" json:"logId"`
 	BuildID   uint      `gorm:"not null;index:log_idx_build_id" json:"buildId"`
-	Build     *Build    `gorm:"foreignKey:BuildID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT" json:"-"`
+	Build     *Build    `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
 	Message   string    `sql:"type:text" json:"message"`
 	Timestamp time.Time `gorm:"not null" json:"timestamp" format:"date-time"`
 }
@@ -165,7 +165,7 @@ const (
 type Artifact struct {
 	ArtifactID uint   `gorm:"primaryKey" json:"artifactId"`
 	BuildID    uint   `gorm:"not null;index:param_idx_build_id" json:"buildId"`
-	Build      *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT" json:"-"`
+	Build      *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
 	Name       string `gorm:"not null" json:"name"`
 	FileName   string `gorm:"nullable" json:"fileName"`
 	Data       []byte `gorm:"nullable" json:"-"`

--- a/database_models.go
+++ b/database_models.go
@@ -12,6 +12,19 @@ import (
 //  - JSON property names:            {type}JSON{FieldName}
 //  - SQL column names:               {type}Column{FieldName}
 
+// Constraint convention in this file:
+//
+// When applying constraints using gorm tags, like:
+//  `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+// we apply it to both referencing fields.
+//
+// Examples:
+//  - Build.Params and BuildParam.Build
+//  - Project.Branches and Branch.Project
+//
+// One seems to take precedence, but to make sure and to keep the code
+// consistent we add it to both referencing fields.
+
 const (
 	providerFieldName      = "Name"
 	providerFieldURL       = "URL"

--- a/database_models.go
+++ b/database_models.go
@@ -85,7 +85,7 @@ const (
 type Branch struct {
 	BranchID  uint     `gorm:"primaryKey" json:"branchId"`
 	ProjectID uint     `gorm:"not null;index:branch_idx_project_id" json:"projectId"`
-	Project   *Project `gorm:"foreignKey:ProjectID" json:"-"`
+	Project   *Project `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
 	Name      string   `gorm:"not null" json:"name"`
 	Default   bool     `gorm:"not null" json:"default"`
 	TokenID   uint     `gorm:"nullable;default:NULL;index:branch_idx_token_id" json:"tokenId"`
@@ -132,7 +132,7 @@ type Build struct {
 type BuildParam struct {
 	BuildParamID uint   `gorm:"primaryKey" json:"-"`
 	BuildID      uint   `gorm:"not null;index:buildparam_idx_build_id" json:"buildId"`
-	Build        *Build `gorm:"foreignKey:BuildID" json:"-"`
+	Build        *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
 	Name         string `gorm:"not null" json:"name"`
 	Value        string `gorm:"nullable" json:"value"`
 }

--- a/database_models.go
+++ b/database_models.go
@@ -67,7 +67,7 @@ type Project struct {
 	ProviderID      uint      `gorm:"nullable;default:NULL;index:project_idx_provider_id" json:"providerId"`
 	Provider        *Provider `gorm:"foreignKey:ProviderID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT" json:"provider"`
 	BuildDefinition string    `sql:"type:text" json:"buildDefinition"`
-	Branches        []Branch  `gorm:"foreignKey:ProjectID" json:"branches"`
+	Branches        []Branch  `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"branches"`
 	GitURL          string    `gorm:"nullable;default:NULL" json:"gitUrl"`
 	// ParsedBuildDefinition is populated when marshalled via MarshalJSON
 	ParsedBuildDefinition interface{} `gorm:"-" json:"build"`
@@ -85,7 +85,7 @@ const (
 type Branch struct {
 	BranchID  uint     `gorm:"primaryKey" json:"branchId"`
 	ProjectID uint     `gorm:"not null;index:branch_idx_project_id" json:"projectId"`
-	Project   *Project `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
+	Project   *Project `gorm:"foreignKey:ProjectID" json:"-"`
 	Name      string   `gorm:"not null" json:"name"`
 	Default   bool     `gorm:"not null" json:"default"`
 	TokenID   uint     `gorm:"nullable;default:NULL;index:branch_idx_token_id" json:"tokenId"`
@@ -122,7 +122,7 @@ type Build struct {
 	GitBranch   string       `gorm:"size:300;default:'';not null" json:"gitBranch"`
 	Environment null.String  `gorm:"nullable;size:40" json:"environment" swaggertype:"string"`
 	Stage       string       `gorm:"size:40;default:'';not null" json:"stage"`
-	Params      []BuildParam `gorm:"foreignKey:BuildID" json:"params"`
+	Params      []BuildParam `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"params"`
 	IsInvalid   bool         `gorm:"not null;default:false" json:"isInvalid"`
 	// Status is populated when marshalled via MarshalJSON
 	Status string `gorm:"-" json:"status"`
@@ -132,7 +132,7 @@ type Build struct {
 type BuildParam struct {
 	BuildParamID uint   `gorm:"primaryKey" json:"-"`
 	BuildID      uint   `gorm:"not null;index:buildparam_idx_build_id" json:"buildId"`
-	Build        *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"-"`
+	Build        *Build `gorm:"foreignKey:BuildID" json:"-"`
 	Name         string `gorm:"not null" json:"name"`
 	Value        string `gorm:"nullable" json:"value"`
 }

--- a/migrations.go
+++ b/migrations.go
@@ -38,7 +38,7 @@ func runDatabaseMigrations(db *gorm.DB) error {
 
 		return nil
 	}); err != nil {
-		return fmt.Errorf("transaction failed: %w", err)
+		return err
 	}
 
 	// since v3.1.0, new constraints with other names are added by GORM

--- a/migrations.go
+++ b/migrations.go
@@ -12,6 +12,21 @@ func runDatabaseMigrations(db *gorm.DB) error {
 		&Branch{}, &Build{}, &Log{},
 		&Artifact{}, &BuildParam{}, &Param{}}
 
+	// since v4.2.1, drop these constraints to refresh the constraint behavior.
+	// Previously it was RESTRICT, now it's CASCADE.
+	//
+	// Perform before AutoMigrate because we want them readded in that step.
+	if err := dropOldConstraints(db, []constraintToDrop{
+		{"artifact", "fk_artifact_build"},
+		{"log", "fk_log_build"},
+		{"build", "fk_build_project"},
+		{"log", "fk_log_build"},
+		{"branch", "fk_project_branches"},
+		{"build_param", "fk_build_params"},
+	}); err != nil {
+		return err
+	}
+
 	db.DisableForeignKeyConstraintWhenMigrating = true
 	if err := db.AutoMigrate(tables...); err != nil {
 		return fmt.Errorf("migrating without constraints: %w", err)


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Changed the constraint behavior between Project and all its children (Branch, Build, BuildParam, Log, Artifact) to `CASCADE` instead of `RESTRICT`, so that we can delete/update a Project without having to do it to the data that is lower in the hierarchy manually.

## Motivation

Closes #62
