### PR TITLE
Fixed some things missed in PR #43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
   Use `GET /build/{buildid}/test-result/list-summary` instead. The response
   data is slightly different; it has additional properties, and does not have a
-  `status` property. (#43)
+  `status` property. (#43, #77)
 
 ## v4.2.0 (2021-09-10)
 

--- a/artifact.go
+++ b/artifact.go
@@ -171,7 +171,8 @@ func (m artifactModule) postBuildArtifactHandler(c *gin.Context) {
 
 // getBuildTestsResultsHandler godoc
 // @deprecated
-// @summary Get build tests results from .trx files. Deprecated, /build/{buildid}/test-results-summary should be used instead.
+// @summary Gets build tests results from .trx files.
+// @description Deprecated, /build/{buildid}/test-result/list-summary should be used instead.
 // @tags artifact
 // @param buildid path int true "Build ID"
 // @success 200 {object} TestsResults

--- a/artifact.go
+++ b/artifact.go
@@ -171,7 +171,7 @@ func (m artifactModule) postBuildArtifactHandler(c *gin.Context) {
 
 // getBuildTestsResultsHandler godoc
 // @deprecated
-// @summary Gets build tests results from .trx files.
+// @summary Get build tests results from .trx files.
 // @description Deprecated, /build/{buildid}/test-result/list-summary should be used instead.
 // @tags artifact
 // @param buildid path int true "Build ID"

--- a/database_models.go
+++ b/database_models.go
@@ -222,5 +222,5 @@ type TestResultDetail struct {
 	Message            null.String      `gorm:"nullable" json:"message" swaggertype:"string"`
 	StartedOn          null.Time        `gorm:"nullable;default:NULL;" json:"startedOn" format:"date-time"`
 	CompletedOn        null.Time        `gorm:"nullable;default:NULL;" json:"completedOn" format:"date-time"`
-	Status             TestResultStatus `gorm:"not null" enums:"Failed,Passed,Skipped" json:"status"`
+	Status             TestResultStatus `gorm:"not null" enum:"Failed,Passed,Skipped" json:"status"`
 }

--- a/database_models.go
+++ b/database_models.go
@@ -137,7 +137,7 @@ type Build struct {
 	Stage               string              `gorm:"size:40;default:'';not null" json:"stage"`
 	Params              []BuildParam        `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"params"`
 	IsInvalid           bool                `gorm:"not null;default:false" json:"isInvalid"`
-	TestResultSummaries []TestResultSummary `gorm:"foreignKey:BuildID" json:"testResultSummaries"`
+	TestResultSummaries []TestResultSummary `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"testResultSummaries"`
 	// Status is populated when marshalled via MarshalJSON
 	Status string `gorm:"-" json:"status"`
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Changed the comment for `artifactModule.getBuildTestsResultsHandler` so that it refers to the correct endpoint.

Fixed a typo in `TestResultDetail` field tags, `enums` changed to `enum`.

Fixed constraint behavior definition for `Build.TestResultSummaries`.

## Motivation

Being pointed to a non-existing endpoint when something is deprecated isn't a great thing, this prevents anybody experiencing that.

The typo made it so the `status` field generated over at [iver-wharf/wharf-api](https://github.com/iver-wharf/wharf-api) was of type `MainTestResultDetail` instead of `string`, causing some issues with simple integration.

The constraint behavior definition was only defined on `TestResultSummary.Build`, which meant that it was set to the default `RESTRICT`, not `CASCADE` that it should be.