### PR TITLE
Split up DB models: part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added packages for "Plain Old Go Objects", with finer-grained decoupling
   between database, HTTP request, and HTTP response models.
-  The Swagger documentation is affected by this, and some unused fields has
+  The Swagger documentation is affected by this, and some unused fields have
   been removed from certain endpoints, such as the `tokenId` in `POST /token`.
   The new packages are: (#78)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   data is slightly different; it has additional properties, and does not have a
   `status` property. (#43)
 
+- Added packages for "Plain Old Go Objects", with finer-grained decoupling
+  between database, HTTP request, and HTTP response models.
+  The Swagger documentation is affected by this, and some unused fields has
+  been removed from certain endpoints, such as the `tokenId` in `POST /token`.
+  The new packages are: (#78)
+
+  - `pkg/model/database`
+  - `pkg/model/request`
+  - `pkg/model/response`
+
+- Fixed `PUT /token` where it did not use the `providerId` value from the HTTP
+  request body. It now sets the provider's token if the field is supplied and
+  non-zero. (#78)
+
 ## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.

--- a/artifact.go
+++ b/artifact.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/iver-wharf/wharf-api/internal/ctxparser"
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"gorm.io/gorm"
 )
@@ -112,7 +113,7 @@ func (m artifactModule) getBuildArtifactHandler(c *gin.Context) {
 		Where(&Artifact{
 			BuildID:    buildID,
 			ArtifactID: artifactID}).
-		Order(artifactColumnArtifactID + " DESC").
+		Order(database.ArtifactColumns.ArtifactID + " DESC").
 		First(&artifact).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -189,7 +190,7 @@ func (m artifactModule) getBuildTestsResultsHandler(c *gin.Context) {
 
 	err := m.Database.
 		Where(&Artifact{BuildID: buildID}).
-		Where(artifactColumnFileName+" LIKE ?", "%.trx").
+		Where(database.ArtifactColumns.FileName+" LIKE ?", "%.trx").
 		Find(&testRunFiles).
 		Error
 	if err != nil {

--- a/branch.go
+++ b/branch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 
 	"github.com/gin-gonic/gin"
@@ -73,7 +74,7 @@ func (m branchModule) PostBranchHandler(c *gin.Context) {
 
 	var existingBranch Branch
 	err := m.Database.
-		Where(&branch, branchFieldProjectID, branchFieldTokenID, branchFieldName).
+		Where(&branch, database.BranchFields.ProjectID, database.BranchFields.TokenID, database.BranchFields.Name).
 		First(&existingBranch).
 		Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -129,7 +130,7 @@ func (m branchModule) PutBranches(branches []Branch) error {
 		var oldDbBranches []Branch
 		if len(branches) > 0 {
 			var firstBranch = branches[0]
-			if err := tx.Where(&firstBranch, branchFieldProjectID).Find(&oldDbBranches).Error; err != nil {
+			if err := tx.Where(&firstBranch, database.BranchFields.ProjectID).Find(&oldDbBranches).Error; err != nil {
 				return err
 			}
 			defaultBranch = firstBranch
@@ -143,7 +144,7 @@ func (m branchModule) PutBranches(branches []Branch) error {
 
 			branchNames = append(branchNames, branch.Name)
 			result := m.Database.
-				Where(&branch, branchFieldProjectID, branchFieldTokenID, branchFieldName).
+				Where(&branch, database.BranchFields.ProjectID, database.BranchFields.TokenID, database.BranchFields.Name).
 				First(&branch)
 			if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 				if err := tx.Create(&branch).Error; err != nil {
@@ -156,8 +157,8 @@ func (m branchModule) PutBranches(branches []Branch) error {
 		if err := tx.
 			Model(&Branch{}).
 			Where(&Branch{ProjectID: defaultBranch.ProjectID, Default: true}).
-			Where(tx.Not(&defaultBranch, branchFieldName)).
-			Select(branchFieldDefault).
+			Where(tx.Not(&defaultBranch, database.BranchFields.Name)).
+			Select(database.BranchFields.Default).
 			Updates(&Branch{Default: false}).Error; err != nil {
 			return err
 		}
@@ -166,7 +167,7 @@ func (m branchModule) PutBranches(branches []Branch) error {
 			if !contains(branchNames, oldDbBranch.Name) {
 				//remove old branch
 				if err := tx.
-					Where(&oldDbBranch, branchFieldProjectID, branchFieldTokenID, branchFieldName).
+					Where(&oldDbBranch, database.BranchFields.ProjectID, database.BranchFields.TokenID, database.BranchFields.Name).
 					Delete(&oldDbBranch).Error; err != nil {
 					return err
 				}

--- a/build.go
+++ b/build.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dustin/go-broadcast"
 	"github.com/gin-gonic/gin"
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"gorm.io/gorm"
 
@@ -130,7 +131,7 @@ func (m buildModule) getBuild(buildID uint) (Build, error) {
 	var build Build
 	if err := m.Database.
 		Where(&Build{BuildID: buildID}).
-		Preload(buildAssocParams).
+		Preload(database.BuildFields.Params).
 		First(&build).
 		Error; err != nil {
 		return Build{}, err

--- a/database_models.go
+++ b/database_models.go
@@ -111,17 +111,6 @@ const (
 	buildColumnName    = "name"
 )
 
-var buildJSONToColumns = map[string]string{
-	"buildId":     buildColumnBuildID,
-	"environment": "environment",
-	"finishedOn":  "completed_on",
-	"scheduledOn": "scheduled_on",
-	"stage":       "stage",
-	"startedOn":   "started_on",
-	"statusId":    "status_id",
-	"isInvalid":   "is_invalid",
-}
-
 // Build holds data about the state of a build. Which parameters was used to
 // start it, what status it holds, et.al.
 type Build struct {

--- a/database_models.go
+++ b/database_models.go
@@ -6,12 +6,6 @@ import (
 	"gopkg.in/guregu/null.v4"
 )
 
-// Consts conventions in this file:
-//  - Go struct field name:           {type}Field{FieldName}
-//  - Association struct field names: {type}Assoc{FieldName}
-//  - JSON property names:            {type}JSON{FieldName}
-//  - SQL column names:               {type}Column{FieldName}
-
 // Constraint convention in this file:
 //
 // When applying constraints using gorm tags, like:
@@ -25,13 +19,6 @@ import (
 // One seems to take precedence, but to make sure and to keep the code
 // consistent we add it to both referencing fields.
 
-const (
-	providerFieldName      = "Name"
-	providerFieldURL       = "URL"
-	providerFieldUploadURL = "UploadURL"
-	providerFieldTokenID   = "TokenID"
-)
-
 // Provider holds metadata about a connection to a remote provider. Some of
 // importance are the URL field of where to find the remote, and the token field
 // used to authenticate.
@@ -44,27 +31,12 @@ type Provider struct {
 	Token      *Token `gorm:"foreignKey:TokenID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT" json:"-"`
 }
 
-const (
-	tokenFieldToken    = "Token"
-	tokenFieldUserName = "UserName"
-)
-
 // Token holds credentials for a remote provider.
 type Token struct {
 	TokenID  uint   `gorm:"primaryKey" json:"tokenId"`
 	Token    string `gorm:"size:500; not null" json:"token" format:"password"`
 	UserName string `gorm:"size:500" json:"userName"`
 }
-
-const (
-	projectFieldProjectID = "ProjectID"
-	projectFieldTokenID   = "TokenID"
-	projectFieldName      = "Name"
-	projectFieldGroupName = "GroupName"
-	projectAssocProvider  = "Provider"
-	projectAssocBranches  = "Branches"
-	projectAssocToken     = "Token"
-)
 
 // Project holds data about an imported project. A lot of the data is expected
 // to be populated with data from the remote provider, such as the description
@@ -86,13 +58,6 @@ type Project struct {
 	ParsedBuildDefinition interface{} `gorm:"-" json:"build"`
 }
 
-const (
-	branchFieldProjectID = "ProjectID"
-	branchFieldName      = "Name"
-	branchFieldDefault   = "Default"
-	branchFieldTokenID   = "TokenID"
-)
-
 // Branch is a single branch in the VCS that can be targeted during builds.
 // For example a Git branch.
 type Branch struct {
@@ -104,12 +69,6 @@ type Branch struct {
 	TokenID   uint     `gorm:"nullable;default:NULL;index:branch_idx_token_id" json:"tokenId"`
 	Token     Token    `gorm:"foreignKey:TokenID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT" json:"-"`
 }
-
-const (
-	buildColumnBuildID = "build_id"
-	buildAssocParams   = "Params"
-	buildColumnName    = "name"
-)
 
 // Build holds data about the state of a build. Which parameters was used to
 // start it, what status it holds, et.al.
@@ -157,11 +116,6 @@ type Param struct {
 	Value        string `json:"value"`
 	DefaultValue string `json:"defaultValue"`
 }
-
-const (
-	artifactColumnArtifactID = "artifact_id"
-	artifactColumnFileName   = "file_name"
-)
 
 // Artifact holds the binary data as well as metadata about that binary such as
 // the file name and which build it belongs to.

--- a/migrations.go
+++ b/migrations.go
@@ -3,15 +3,16 @@ package main
 import (
 	"fmt"
 
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"gorm.io/gorm"
 )
 
 func runDatabaseMigrations(db *gorm.DB) error {
 	tables := []interface{}{
-		&Token{}, &Provider{}, &Project{},
-		&Branch{}, &Build{}, &Log{},
-		&Artifact{}, &BuildParam{}, &Param{},
-		&TestResultDetail{}, &TestResultSummary{}}
+		&database.Token{}, &database.Provider{}, &database.Project{},
+		&database.Branch{}, &database.Build{}, &database.Log{},
+		&database.Artifact{}, &database.BuildParam{}, &database.Param{},
+		&database.TestResultDetail{}, &database.TestResultSummary{}}
 
 	db.DisableForeignKeyConstraintWhenMigrating = true
 	if err := db.AutoMigrate(tables...); err != nil {
@@ -62,7 +63,7 @@ func runDatabaseMigrations(db *gorm.DB) error {
 
 	// since v3.1.0, the token.provider_id column was removed as it induced a
 	// circular dependency between the token and provider tables
-	if err := dropOldColumn(db, &Token{}, "provider_id"); err != nil {
+	if err := dropOldColumn(db, &database.Token{}, "provider_id"); err != nil {
 		return err
 	}
 

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -126,6 +126,15 @@ var BranchFields = struct {
 	TokenID:   "TokenID",
 }
 
+// BranchColumns holds the DB column names for each field.
+// Useful in GORM .Order() statements to order the results based on a specific
+// column, which does not support the regular Go field names.
+var BranchColumns = struct{
+	BranchID string
+}{
+	BranchID: "branch_id",
+}
+
 // Branch is a single branch in the VCS that can be targeted during builds.
 // For example a Git branch.
 type Branch struct {

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -1,0 +1,296 @@
+// Package database contains plain old Go types used by GORM as database models
+// with GORM-specific Go tags.
+package database
+
+import (
+	"time"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+// Structs naming conventions in this file:
+//  - Go struct field names:  {type}Fields
+//  - SQL column names:       {type}Columns
+//
+// Fields are added on-demand to these structs.
+
+// Constraint convention in this file:
+//
+// When applying constraints using gorm tags, like:
+//  `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+// we apply it to both referencing fields.
+//
+// Examples:
+//  - Build.Params and BuildParam.Build
+//  - Project.Branches and Branch.Project
+//
+// One seems to take precedence, but to make sure and to keep the code
+// consistent we add it to both referencing fields.
+
+// ProviderFields holds the Go struct field names for each field.
+// Useful in GORM .Where() statements to only select certain fields or in GORM
+// Preload statements to select the correct field to preload.
+var ProviderFields = struct {
+	Name      string
+	URL       string
+	UploadURL string
+	TokenID   string
+}{
+	Name:      "Name",
+	URL:       "URL",
+	UploadURL: "UploadURL",
+	TokenID:   "TokenID",
+}
+
+// Provider holds metadata about a connection to a remote provider. Some of
+// importance are the URL field of where to find the remote, and the token field
+// used to authenticate.
+type Provider struct {
+	ProviderID uint   `gorm:"primaryKey"`
+	Name       string `gorm:"size:20;not null"enum:"azuredevops,gitlab,github"`
+	URL        string `gorm:"size:500;not null"`
+	UploadURL  string `gorm:"size:500"`
+	TokenID    uint   `gorm:"nullable;default:NULL;index:provider_idx_token_id"`
+	Token      *Token `gorm:"foreignKey:TokenID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT"`
+}
+
+// TokenFields holds the Go struct field names for each field.
+// Useful in GORM .Where() statements to only select certain fields or in GORM
+// Preload statements to select the correct field to preload.
+var TokenFields = struct {
+	Token    string
+	UserName string
+}{
+	Token:    "Token",
+	UserName: "UserName",
+}
+
+// Token holds credentials for a remote provider.
+type Token struct {
+	TokenID  uint   `gorm:"primaryKey"`
+	Token    string `gorm:"size:500; not null"`
+	UserName string `gorm:"size:500"`
+}
+
+// ProjectFields holds the Go struct field names for each field.
+// Useful in GORM .Where() statements to only select certain fields or in GORM
+// Preload statements to select the correct field to preload.
+var ProjectFields = struct {
+	ProjectID string
+	Name      string
+	GroupName string
+	TokenID   string
+	Token     string
+	Provider  string
+	Branches  string
+}{
+	ProjectID: "ProjectID",
+	Name:      "Name",
+	GroupName: "GroupName",
+	TokenID:   "TokenID",
+	Token:     "Token",
+	Provider:  "Provider",
+	Branches:  "Branches",
+}
+
+// Project holds data about an imported project. A lot of the data is expected
+// to be populated with data from the remote provider, such as the description
+// and avatar.
+type Project struct {
+	ProjectID       uint      `gorm:"primaryKey"`
+	Name            string    `gorm:"size:500;not null"`
+	GroupName       string    `gorm:"size:500"`
+	Description     string    `gorm:"size:500"`
+	AvatarURL       string    `gorm:"size:500"`
+	TokenID         uint      `gorm:"nullable;default:NULL;index:project_idx_token_id"`
+	Token           *Token    `gorm:"foreignKey:TokenID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT"`
+	ProviderID      uint      `gorm:"nullable;default:NULL;index:project_idx_provider_id"`
+	Provider        *Provider `gorm:"foreignKey:ProviderID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT"`
+	BuildDefinition string    `sql:"type:text"`
+	Branches        []Branch  `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	GitURL          string    `gorm:"nullable;default:NULL"`
+}
+
+// BranchFields holds the Go struct field names for each field.
+// Useful in GORM .Where() statements to only select certain fields or in GORM
+// Preload statements to select the correct field to preload.
+var BranchFields = struct {
+	ProjectID string
+	Name      string
+	Default   string
+	TokenID   string
+}{
+	ProjectID: "ProjectID",
+	Name:      "Name",
+	Default:   "Default",
+	TokenID:   "TokenID",
+}
+
+// Branch is a single branch in the VCS that can be targeted during builds.
+// For example a Git branch.
+type Branch struct {
+	BranchID  uint     `gorm:"primaryKey"`
+	ProjectID uint     `gorm:"not null;index:branch_idx_project_id"`
+	Project   *Project `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Name      string   `gorm:"not null"`
+	Default   bool     `gorm:"not null"`
+	TokenID   uint     `gorm:"nullable;default:NULL;index:branch_idx_token_id"`
+	Token     Token    `gorm:"foreignKey:TokenID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT"`
+}
+
+// BuildFields holds the Go struct field names for each field.
+// Useful in GORM .Where() statements to only select certain fields or in GORM
+// Preload statements to select the correct field to preload.
+var BuildFields = struct {
+	Params string
+}{
+	Params: "Params",
+}
+
+// BuildColumns holds the DB column names for each field.
+// Useful in GORM .Order() statements to order the results based on a specific
+// column, which does not support the regular Go field names.
+var BuildColumns = struct {
+	BuildID     string
+	StatusID    string
+	ScheduledOn string
+	StartedOn   string
+	CompletedOn string
+	Environment string
+	Stage       string
+	IsInvalid   string
+}{
+	BuildID:     "build_id",
+	StatusID:    "status_id",
+	ScheduledOn: "scheduled_on",
+	StartedOn:   "started_on",
+	CompletedOn: "completed_on",
+	Environment: "environment",
+	Stage:       "stage",
+	IsInvalid:   "is_invalid",
+}
+
+// Build holds data about the state of a build. Which parameters was used to
+// start it, what status it holds, et.al.
+type Build struct {
+	BuildID             uint                `gorm:"primaryKey"`
+	StatusID            BuildStatus         `gorm:"not null"`
+	ProjectID           uint                `gorm:"not null;index:build_idx_project_id"`
+	Project             *Project            `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	ScheduledOn         null.Time           `gorm:"nullable;default:NULL"`
+	StartedOn           null.Time           `gorm:"nullable;default:NULL"`
+	CompletedOn         null.Time           `gorm:"nullable;default:NULL"`
+	GitBranch           string              `gorm:"size:300;default:'';not null"`
+	Environment         null.String         `gorm:"nullable;size:40"swaggertype:"string"`
+	Stage               string              `gorm:"size:40;default:'';not null"`
+	Params              []BuildParam        `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	IsInvalid           bool                `gorm:"not null;default:false"`
+	TestResultSummaries []TestResultSummary `gorm:"foreignKey:BuildID"`
+}
+
+// BuildStatus is an enum of different states for a build.
+type BuildStatus int
+
+const (
+	// BuildScheduling means the build has been registered, but no code
+	// execution has begun yet. This is usually quite an ephemeral state.
+	BuildScheduling BuildStatus = iota
+	// BuildRunning means the build is executing right now. The execution
+	// engine has load in the target code paths and repositories.
+	BuildRunning
+	// BuildCompleted means the build has finished execution successfully.
+	BuildCompleted
+	// BuildFailed means that something went wrong with the build. Could be a
+	// misconfiguration in the .wharf-ci.yml file, or perhaps a scripting error
+	// in some build step.
+	BuildFailed
+)
+
+// BuildParam holds the name and value of an input parameter fed into a build.
+type BuildParam struct {
+	BuildParamID uint   `gorm:"primaryKey"`
+	BuildID      uint   `gorm:"not null;index:buildparam_idx_build_id"`
+	Build        *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Name         string `gorm:"not null"`
+	Value        string `gorm:"nullable"`
+}
+
+// Log is a single logged line for a build.
+type Log struct {
+	LogID     uint      `gorm:"primaryKey"`
+	BuildID   uint      `gorm:"not null;index:log_idx_build_id"`
+	Build     *Build    `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Message   string    `sql:"type:text"`
+	Timestamp time.Time `gorm:"not null"`
+}
+
+// Param holds the definition of an input parameter for a project.
+type Param struct {
+	ParamID      int    `gorm:"primaryKey"`
+	Name         string `gorm:"not null"`
+	Type         string `gorm:"not null"`
+	Value        string
+	DefaultValue string
+}
+
+// ArtifactColumns holds the DB column names for each field.
+// Useful in GORM .Order() statements to order the results based on a specific
+// column, which does not support the regular Go field names.
+var ArtifactColumns = struct {
+	ArtifactID string
+	FileName   string
+}{
+	ArtifactID: "artifact_id",
+	FileName:   "file_name",
+}
+
+// Artifact holds the binary data as well as metadata about that binary such as
+// the file name and which build it belongs to.
+type Artifact struct {
+	ArtifactID uint   `gorm:"primaryKey"`
+	BuildID    uint   `gorm:"not null;index:artifact_idx_build_id"`
+	Build      *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Name       string `gorm:"not null"`
+	FileName   string `gorm:"nullable"`
+	Data       []byte `gorm:"nullable"`
+}
+
+// TestResultSummary contains data about a single test result file.
+type TestResultSummary struct {
+	TestResultSummaryID uint      `gorm:"primaryKey"`
+	FileName            string    `gorm:"nullable"`
+	ArtifactID          uint      `gorm:"not null;index:testresultsummary_idx_artifact_id"`
+	Artifact            *Artifact `gorm:"foreignKey:ArtifactID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL"`
+	BuildID             uint      `gorm:"not null;index:testresultsummary_idx_build_id"`
+	Build               *Build    `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Total               uint      `gorm:"not null"`
+	Failed              uint      `gorm:"not null"`
+	Passed              uint      `gorm:"not null"`
+	Skipped             uint      `gorm:"not null"`
+}
+
+// TestResultStatus is an enum of different states a test result can be in.
+type TestResultStatus string
+
+const (
+	// TestResultStatusSuccess means the test succeeded.
+	TestResultStatusSuccess TestResultStatus = "Success"
+	// TestResultStatusFailed means the test failed.
+	TestResultStatusFailed TestResultStatus = "Failed"
+	// TestResultStatusSkipped means the test was skipped.
+	TestResultStatusSkipped TestResultStatus = "Skipped"
+)
+
+// TestResultDetail contains data about a single test in a test result file.
+type TestResultDetail struct {
+	TestResultDetailID uint             `gorm:"primaryKey"`
+	ArtifactID         uint             `gorm:"not null;index:testresultdetail_idx_artifact_id"`
+	Artifact           *Artifact        `gorm:"foreignKey:ArtifactID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL"`
+	BuildID            uint             `gorm:"not null;index:testresultdetail_idx_build_id"`
+	Build              *Build           `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Name               string           `gorm:"not null"`
+	Message            null.String      `gorm:"nullable"`
+	StartedOn          null.Time        `gorm:"nullable;default:NULL;"`
+	CompletedOn        null.Time        `gorm:"nullable;default:NULL;"`
+	Status             TestResultStatus `gorm:"not null"`
+}

--- a/pkg/model/request/request.go
+++ b/pkg/model/request/request.go
@@ -1,0 +1,27 @@
+// Package request contains plain old Go types used in the Gin endpoint handlers
+// and Swaggo documentation for the HTTP request models, with Gin- and
+// Swaggo-specific Go tags.
+package request
+
+// Reference doc about the Go tags:
+//  TAG                  SOURCE                   DESCRIPTION
+//  json:"foo"           encoding/json            Serializes field with the name "foo"
+//  format:"date-time"   swaggo/swag              Swagger format
+//  validate:"required"  swaggo/swag              Mark Swagger field as required/non-nullable
+//  binding:"required"   go-playground/validator  Gin's Bind will error if nil or zero
+//
+// go-playground/validator uses the tag "validate" by default, but Gin overrides
+// changes that to "binding".
+
+// TokenSearch holds values used in verbatim searches for tokens.
+type TokenSearch struct {
+	Token    string `json:"token" format:"password"`
+	UserName string `json:"userName"`
+}
+
+// Token specifies fields when creating a new token.
+type Token struct {
+	Token      string `json:"token" format:"password" validate:"required"`
+	UserName   string `json:"userName" validate:"required"`
+	ProviderID uint   `json:"providerId"`
+}

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -1,0 +1,10 @@
+// Package response contains plain old Go types returned by wharf-web in the
+// HTTP responses, with Swaggo-specific Go tags.
+package response
+
+// Token holds credentials for a remote provider.
+type Token struct {
+	TokenID  uint   `json:"tokenId"`
+	Token    string `json:"token" format:"password"`
+	UserName string `json:"userName"`
+}

--- a/project.go
+++ b/project.go
@@ -64,11 +64,11 @@ func (m projectModule) FindProjectByID(id uint) (Project, error) {
 	var project Project
 	err := m.Database.Set("gorm:auto_preload", false).
 		Where(&Project{ProjectID: id}).
-		Preload(projectAssocProvider).
-		Preload(projectAssocBranches, func(db *gorm.DB) *gorm.DB {
-			return db.Order(buildColumnName)
+		Preload(database.ProjectFields.Provider).
+		Preload(database.ProjectFields.Branches, func(db *gorm.DB) *gorm.DB {
+			return db.Order(database.BuildColumns.BuildID)
 		}).
-		Preload(projectAssocToken).
+		Preload(database.ProjectFields.Token).
 		First(&project).
 		Error
 
@@ -85,9 +85,9 @@ func (m projectModule) FindProjectByID(id uint) (Project, error) {
 func (m projectModule) getProjectsHandler(c *gin.Context) {
 	var projects []Project
 	err := m.Database.
-		Preload(projectAssocProvider).
-		Preload(projectAssocBranches, func(db *gorm.DB) *gorm.DB {
-			return db.Order(buildColumnName)
+		Preload(database.ProjectFields.Provider).
+		Preload(database.ProjectFields.Branches, func(db *gorm.DB) *gorm.DB {
+			return db.Order(database.BuildColumns.BuildID)
 		}).
 		Find(&projects).
 		Error
@@ -115,7 +115,7 @@ func (m projectModule) searchProjectsHandler(c *gin.Context) {
 	var projects []Project
 	err := m.Database.
 		Where(&query).
-		Preload(projectAssocProvider).
+		Preload(database.ProjectFields.Provider).
 		Find(&projects).
 		Error
 	if err != nil {
@@ -244,7 +244,7 @@ func (m projectModule) postProjectHandler(c *gin.Context) {
 	var existingProject Project
 	if project.ProjectID != 0 {
 		err := m.Database.
-			Where(&project, projectFieldProjectID).
+			Where(&project, database.ProjectFields.ProjectID).
 			First(&existingProject).
 			Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -260,7 +260,7 @@ func (m projectModule) postProjectHandler(c *gin.Context) {
 		}
 	} else {
 		err := m.Database.
-			Where(&project, projectFieldGroupName, projectFieldTokenID, projectFieldName).
+			Where(&project, database.ProjectFields.GroupName, database.ProjectFields.TokenID, database.ProjectFields.Name).
 			First(&existingProject).
 			Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -361,7 +361,7 @@ func (m projectModule) putProjectHandler(c *gin.Context) {
 		}
 	} else {
 		err := m.Database.
-			Where(&project, projectFieldName, projectFieldGroupName).
+			Where(&project, database.ProjectFields.Name, database.ProjectFields.GroupName).
 			First(&existingProject).
 			Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -702,7 +702,7 @@ func getParams(project Project, build Build, vars []BuildParam, wharfInstanceID 
 	return params, nil
 }
 
-var defaultGetBuildsOrderBy = orderby.OrderBy{Column: buildColumnBuildID, Direction: orderby.Desc}
+var defaultGetBuildsOrderBy = orderby.OrderBy{Column: database.BuildColumns.BuildID, Direction: orderby.Desc}
 
 func (m projectModule) getBuilds(projectID uint, limit int, offset int, orderBySlice []orderby.OrderBy) ([]Build, error) {
 	var builds []Build

--- a/project.go
+++ b/project.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/gin-gonic/gin"
 	"github.com/iver-wharf/messagebus-go"
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/iver-wharf/wharf-api/pkg/orderby"
 	"github.com/iver-wharf/wharf-core/pkg/problem"
 	"gopkg.in/guregu/null.v4"
@@ -122,6 +123,17 @@ func (m projectModule) searchProjectsHandler(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, projects)
+}
+
+var buildJSONToColumns = map[string]string{
+	"buildId":     database.BuildColumns.BuildID,
+	"environment": database.BuildColumns.Environment,
+	"finishedOn":  database.BuildColumns.CompletedOn,
+	"scheduledOn": database.BuildColumns.ScheduledOn,
+	"startedOn":   database.BuildColumns.StartedOn,
+	"stage":       database.BuildColumns.Stage,
+	"statusId":    database.BuildColumns.StatusID,
+	"isInvalid":   database.BuildColumns.IsInvalid,
 }
 
 // getBuildsSliceHandler godoc

--- a/project.go
+++ b/project.go
@@ -66,7 +66,7 @@ func (m projectModule) FindProjectByID(id uint) (Project, error) {
 		Where(&Project{ProjectID: id}).
 		Preload(database.ProjectFields.Provider).
 		Preload(database.ProjectFields.Branches, func(db *gorm.DB) *gorm.DB {
-			return db.Order(database.BuildColumns.BuildID)
+			return db.Order(database.BranchColumns.BranchID)
 		}).
 		Preload(database.ProjectFields.Token).
 		First(&project).
@@ -87,7 +87,7 @@ func (m projectModule) getProjectsHandler(c *gin.Context) {
 	err := m.Database.
 		Preload(database.ProjectFields.Provider).
 		Preload(database.ProjectFields.Branches, func(db *gorm.DB) *gorm.DB {
-			return db.Order(database.BuildColumns.BuildID)
+			return db.Order(database.BranchColumns.BranchID)
 		}).
 		Find(&projects).
 		Error

--- a/provider.go
+++ b/provider.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"github.com/iver-wharf/wharf-core/pkg/problem"
 	"gorm.io/gorm"
@@ -134,7 +135,7 @@ func (m providerModule) postSearchProviderHandler(c *gin.Context) {
 	var providers []Provider
 	if provider.TokenID != 0 {
 		err := m.Database.
-			Where(&provider, providerFieldName, providerFieldURL, providerFieldUploadURL, providerFieldTokenID).
+			Where(&provider, database.ProviderFields.Name, database.ProviderFields.URL, database.ProviderFields.UploadURL, database.ProviderFields.TokenID).
 			Find(&providers).
 			Error
 		if err != nil {
@@ -145,7 +146,7 @@ func (m providerModule) postSearchProviderHandler(c *gin.Context) {
 		}
 	} else {
 		err := m.Database.
-			Where(&provider, providerFieldName, providerFieldURL, providerFieldUploadURL).
+			Where(&provider, database.ProviderFields.Name, database.ProviderFields.URL, database.ProviderFields.UploadURL).
 			Find(&providers).
 			Error
 		if err != nil {

--- a/token.go
+++ b/token.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 
 	"net/http"
@@ -103,7 +104,7 @@ func (m tokenModule) postSearchTokenHandler(c *gin.Context) {
 
 	var tokens []Token
 	err := m.Database.
-		Where(&token, tokenFieldToken, tokenFieldUserName).
+		Where(&token, database.TokenFields.Token, database.TokenFields.UserName).
 		Find(&tokens).
 		Error
 	if err != nil {

--- a/token.go
+++ b/token.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/iver-wharf/wharf-api/pkg/model/database"
+	"github.com/iver-wharf/wharf-api/pkg/model/request"
+	"github.com/iver-wharf/wharf-api/pkg/model/response"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 
 	"net/http"
@@ -35,27 +37,32 @@ func (m tokenModule) Register(g *gin.RouterGroup) {
 // getTokensHandler godoc
 // @summary Returns first 100 tokens
 // @tags token
-// @success 200 {object} []Token
+// @success 200 {object} []response.Token
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /tokens [get]
 func (m tokenModule) getTokensHandler(c *gin.Context) {
 
-	var tokens []Token
-	err := m.Database.Limit(100).Find(&tokens).Error
+	var dbTokens []database.Token
+	err := m.Database.Limit(100).Find(&dbTokens).Error
 	if err != nil {
 		ginutil.WriteDBReadError(c, err, "Failed fetching list of tokens from database.")
 		return
 	}
 
-	c.JSON(http.StatusOK, tokens)
+	resTokens := make([]response.Token, len(dbTokens))
+	for i, dbToken := range dbTokens {
+		resTokens[i] = dbTokenToResponseToken(dbToken)
+	}
+
+	c.JSON(http.StatusOK, resTokens)
 }
 
 // getTokenHandler godoc
 // @summary Returns token with selected token ID
 // @tags token
 // @param tokenid path int true "Token ID"
-// @success 200 {object} Token
+// @success 200 {object} response.Token
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
@@ -66,8 +73,8 @@ func (m tokenModule) getTokenHandler(c *gin.Context) {
 		return
 	}
 
-	var token Token
-	err := m.Database.First(&token, tokenID).Error
+	var dbToken database.Token
+	err := m.Database.First(&dbToken, tokenID).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		ginutil.WriteDBNotFound(c, fmt.Sprintf(
 			"Token with ID %d was not found.", tokenID))
@@ -78,7 +85,8 @@ func (m tokenModule) getTokenHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, token)
+	resToken := dbTokenToResponseToken(dbToken)
+	c.JSON(http.StatusOK, resToken)
 }
 
 // postSearchTokenHandler godoc
@@ -88,40 +96,41 @@ func (m tokenModule) getTokenHandler(c *gin.Context) {
 // @tags token
 // @accept json
 // @produce json
-// @param token body Token _ "token object"
-// @success 200 {object} []Token
+// @param token body request.TokenSearch _ "Token search criteria"
+// @success 200 {object} []response.Token
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /tokens/search [post]
 func (m tokenModule) postSearchTokenHandler(c *gin.Context) {
-	var token Token
-	if err := c.ShouldBindJSON(&token); err != nil {
+	var reqToken request.Token
+	if err := c.ShouldBindJSON(&reqToken); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
 			"One or more parameters failed to parse when reading the request body for the token object to search with.")
 		return
 	}
 
-	var tokens []Token
+	var dbTokens []database.Token
 	err := m.Database.
-		Where(&token, database.TokenFields.Token, database.TokenFields.UserName).
-		Find(&tokens).
+		Where(&database.Token{
+			Token:    reqToken.Token,
+			UserName: reqToken.UserName,
+		}, database.TokenFields.Token, database.TokenFields.UserName).
+		Find(&dbTokens).
 		Error
 	if err != nil {
 		ginutil.WriteDBReadError(c, err, fmt.Sprintf(
 			"Failed searching for token by value and with username %q in database.",
-			token.UserName))
+			reqToken.UserName))
 		return
 	}
 
-	c.JSON(http.StatusOK, tokens)
-}
+	resTokens := make([]response.Token, len(dbTokens))
+	for i, dbToken := range dbTokens {
+		resTokens[i] = dbTokenToResponseToken(dbToken)
+	}
 
-// TokenWithProviderID is an extended token model that also contains the ID of
-// an associated provider.
-type TokenWithProviderID struct {
-	Token
-	ProviderID uint `json:"providerId"`
+	c.JSON(http.StatusOK, resTokens)
 }
 
 // postTokenHandler godoc
@@ -130,57 +139,56 @@ type TokenWithProviderID struct {
 // @tags token
 // @accept json
 // @produce json
-// @param token body TokenWithProviderID _ "token object"
-// @success 201 {object} Token
+// @param token body request.Token _ "Token to create"
+// @success 201 {object} response.Token
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 404 {object} problem.Response "Referenced provider not found"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /token [post]
 func (m tokenModule) postTokenHandler(c *gin.Context) {
-	var (
-		tokenWithProviderID TokenWithProviderID
-		token               *Token
-		providerID          uint
-	)
-
-	if err := c.ShouldBindJSON(&tokenWithProviderID); err != nil {
+	var reqToken request.Token
+	if err := c.ShouldBindJSON(&reqToken); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
 			"One or more parameters failed to parse when reading the request body for the token object to create.")
 		return
 	}
-	token = &tokenWithProviderID.Token
-	providerID = tokenWithProviderID.ProviderID
 
-	if providerID != 0 {
-		var provider Provider
-		err := m.Database.Find(&provider, providerID).Error
+	dbToken := database.Token{
+		Token:    reqToken.Token,
+		UserName: reqToken.UserName,
+	}
+
+	if reqToken.ProviderID != 0 {
+		var provider database.Provider
+		err := m.Database.Find(&provider, reqToken.ProviderID).Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			ginutil.WriteDBNotFound(c, fmt.Sprintf(
 				"Provider with ID %d was not found when creating token.",
-				providerID))
+				reqToken.ProviderID))
 			return
 		} else if err != nil {
 			ginutil.WriteDBReadError(c, err, fmt.Sprintf(
 				"Failed fetching project with ID %d from database when creating token.",
-				providerID))
+				reqToken.ProviderID))
 			return
 		}
-		provider.Token = token
+		provider.Token = &dbToken
 		if err := m.Database.Save(&provider).Error; err != nil {
 			ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
 				"Failed updating provider with ID %d with a new token.",
-				providerID))
+				reqToken.ProviderID))
 			return
 		}
 	} else {
-		if err := m.Database.Create(token).Error; err != nil {
+		if err := m.Database.Create(&dbToken).Error; err != nil {
 			ginutil.WriteDBWriteError(c, err, "Failed creating a new token.")
 			return
 		}
 	}
 
-	c.JSON(http.StatusCreated, token)
+	resToken := dbTokenToResponseToken(dbToken)
+	c.JSON(http.StatusCreated, resToken)
 }
 
 // postTokenHandler godoc
@@ -189,24 +197,62 @@ func (m tokenModule) postTokenHandler(c *gin.Context) {
 // @tags token
 // @accept json
 // @produce json
-// @param token body TokenWithProviderID _ "token object"
-// @success 200 {object} Token
+// @param token body request.Token _ "Token to add or update"
+// @success 200 {object} response.Token
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /token [put]
 func (m tokenModule) putTokenHandler(c *gin.Context) {
-	var inputToken Token
-	if err := c.ShouldBindJSON(&inputToken); err != nil {
+	var reqToken request.Token
+	if err := c.ShouldBindJSON(&reqToken); err != nil {
 		ginutil.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")
 		return
 	}
-	var token Token
-	if err := m.Database.Where(inputToken).FirstOrCreate(&token).Error; err != nil {
+	dbToken := database.Token{
+		Token:    reqToken.Token,
+		UserName: reqToken.UserName,
+	}
+	var dbProvider database.Provider
+	if reqToken.ProviderID != 0 {
+		if err := m.Database.Find(&dbProvider, reqToken.ProviderID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				ginutil.WriteDBNotFound(c, fmt.Sprintf("No provider was found by ID %d when fetching or creating token by username %q.",
+					reqToken.ProviderID,
+					reqToken.UserName))
+			} else {
+				ginutil.WriteDBReadError(c, err, fmt.Sprintf(
+					"Failed to find associate provider by ID %d when fetching or creating token by username %q.",
+					reqToken.ProviderID,
+					reqToken.UserName))
+			}
+			return
+		}
+	}
+	err := m.Database.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where(dbToken).FirstOrCreate(&dbToken).Error; err != nil {
+			return err
+		}
+		if reqToken.ProviderID != 0 {
+			dbProvider.Token = &dbToken
+			dbProvider.TokenID = dbToken.TokenID
+			return tx.Save(&dbProvider).Error
+		}
+		return nil
+	})
+	if err != nil {
 		ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
 			"Failed fetch or create on token by username %q and token value.",
-			inputToken.UserName))
-		return
+			reqToken.UserName))
 	}
-	c.JSON(http.StatusOK, token)
+	resToken := dbTokenToResponseToken(dbToken)
+	c.JSON(http.StatusOK, resToken)
+}
+
+func dbTokenToResponseToken(token database.Token) response.Token {
+	return response.Token{
+		TokenID:  token.TokenID,
+		Token:    token.Token,
+		UserName: token.UserName,
+	}
 }

--- a/token.go
+++ b/token.go
@@ -42,7 +42,6 @@ func (m tokenModule) Register(g *gin.RouterGroup) {
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /tokens [get]
 func (m tokenModule) getTokensHandler(c *gin.Context) {
-
 	var dbTokens []database.Token
 	err := m.Database.Limit(100).Find(&dbTokens).Error
 	if err != nil {
@@ -50,11 +49,7 @@ func (m tokenModule) getTokensHandler(c *gin.Context) {
 		return
 	}
 
-	resTokens := make([]response.Token, len(dbTokens))
-	for i, dbToken := range dbTokens {
-		resTokens[i] = dbTokenToResponseToken(dbToken)
-	}
-
+	resTokens := dbTokensToResponseTokens(dbTokens)
 	c.JSON(http.StatusOK, resTokens)
 }
 
@@ -125,11 +120,7 @@ func (m tokenModule) postSearchTokenHandler(c *gin.Context) {
 		return
 	}
 
-	resTokens := make([]response.Token, len(dbTokens))
-	for i, dbToken := range dbTokens {
-		resTokens[i] = dbTokenToResponseToken(dbToken)
-	}
-
+	resTokens := dbTokensToResponseTokens(dbTokens)
 	c.JSON(http.StatusOK, resTokens)
 }
 
@@ -245,14 +236,23 @@ func (m tokenModule) putTokenHandler(c *gin.Context) {
 			"Failed fetch or create on token by username %q and token value.",
 			reqToken.UserName))
 	}
+
 	resToken := dbTokenToResponseToken(dbToken)
 	c.JSON(http.StatusOK, resToken)
 }
 
-func dbTokenToResponseToken(token database.Token) response.Token {
+func dbTokensToResponseTokens(dbTokens []database.Token) []response.Token {
+	resTokens := make([]response.Token, len(dbTokens))
+	for i, dbToken := range dbTokens {
+		resTokens[i] = dbTokenToResponseToken(dbToken)
+	}
+	return resTokens
+}
+
+func dbTokenToResponseToken(dbToken database.Token) response.Token {
 	return response.Token{
-		TokenID:  token.TokenID,
-		Token:    token.Token,
-		UserName: token.UserName,
+		TokenID:  dbToken.TokenID,
+		Token:    dbToken.Token,
+		UserName: dbToken.UserName,
 	}
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added packages
  - `pkg/model/database`
  - `pkg/model/request`
  - `pkg/model/response`
- Changed usage of `{type}Field{FieldName}` to `database.{Type}Fields.{FieldName}`
- Updated `token.go` to use new models
- Updated migrations to use new models
- Added transaction to PUT token and made it associate with the provider by the ID from the request JSON.

## Motivation

Related to #72, but doesn't close it yet as there are a lot more files to be dealt with.

This is like a taste sample. Better to get feedback on this early, as changing the remaining files will result in a giant PR that does pretty much the same stuff everywhere.

The -Search model will remain until we drop the backward compatibility, but only be used in the endpoints that will be deprecated in #71.

## Preview

The Swagger documentation now specifies more relevant models. I played around with the [`validate` tag from Swaggo](https://github.com/swaggo/swag#available) as well to mark some fields as required (the small red asterisk):

![Screenshot from 2021-09-16 17-34-30](https://user-images.githubusercontent.com/2477952/133644818-219046d1-e1b5-4f5e-bb51-bef057eec198.png)
![Screenshot from 2021-09-16 17-35-03](https://user-images.githubusercontent.com/2477952/133644819-48b0d382-2775-47f5-9fd5-1b460ea24ed4.png)
![Screenshot from 2021-09-16 17-54-05](https://user-images.githubusercontent.com/2477952/133644987-241a4666-30d4-482e-aff6-2107a6ab382a.png)
