### PR TITLE
Added swaggo operation ID & renamed handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   ID has not been shown to have any benefits. Please refer to the
   `GET /project/{projectId}` endpoint instead. (#75)
 
+- Added Swagger operation IDs to all endpoints. This has no effect on the APIs
+  behavior, but affects code generators. (#79)
+
 ## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   ID has not been shown to have any benefits. Please refer to the
   `GET /project/{projectId}` endpoint instead. (#75)
 
-- Added Swagger operation IDs to all endpoints. This has no effect on the APIs
+- Added Swagger operation IDs to all endpoints. This has no effect on the API's
   behavior, but affects code generators. (#79)
 
 ## v4.2.0 (2021-09-10)

--- a/artifact.go
+++ b/artifact.go
@@ -48,14 +48,15 @@ type TestsResults struct {
 }
 
 func (m artifactModule) Register(g *gin.RouterGroup) {
-	g.GET("/artifacts", m.getBuildArtifactsHandler)
+	g.GET("/artifacts", m.getBuildArtifactListHandler)
 	g.GET("/artifact/:artifactId", m.getBuildArtifactHandler)
-	g.POST("/artifact", m.postBuildArtifactHandler)
+	g.POST("/artifact", m.createBuildArtifactHandler)
 	// deprecated
-	g.GET("/tests-results", m.getBuildTestsResultsHandler)
+	g.GET("/tests-results", m.getBuildTestResultListHandler)
 }
 
-// getBuildArtifactsHandler godoc
+// getBuildArtifactListHandler godoc
+// @id getBuildArtifactList
 // @summary Get list of build artifacts
 // @tags artifact
 // @param buildId path int true "Build ID"
@@ -64,7 +65,7 @@ func (m artifactModule) Register(g *gin.RouterGroup) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/artifacts [get]
-func (m artifactModule) getBuildArtifactsHandler(c *gin.Context) {
+func (m artifactModule) getBuildArtifactListHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return
@@ -86,6 +87,7 @@ func (m artifactModule) getBuildArtifactsHandler(c *gin.Context) {
 }
 
 // getBuildArtifactHandler godoc
+// @id getBuildArtifact
 // @summary Get build artifact
 // @tags artifact
 // @param buildId path int true "Build ID"
@@ -135,7 +137,8 @@ func (m artifactModule) getBuildArtifactHandler(c *gin.Context) {
 	c.Data(http.StatusOK, mimeType, artifact.Data)
 }
 
-// postBuildArtifactHandler godoc
+// createBuildArtifactHandler godoc
+// @id createBuildArtifact
 // @summary Post build artifact
 // @tags artifact
 // @accept multipart/form-data
@@ -147,7 +150,7 @@ func (m artifactModule) getBuildArtifactHandler(c *gin.Context) {
 // @failure 404 {object} problem.Response "Artifact not found"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/artifact [post]
-func (m artifactModule) postBuildArtifactHandler(c *gin.Context) {
+func (m artifactModule) createBuildArtifactHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return
@@ -169,7 +172,8 @@ func (m artifactModule) postBuildArtifactHandler(c *gin.Context) {
 	c.Status(http.StatusCreated)
 }
 
-// getBuildTestsResultsHandler godoc
+// getBuildTestResultListHandler godoc
+// @id getBuildTestResultList
 // @deprecated
 // @summary Get build tests results from .trx files.
 // @description Deprecated, /build/{buildid}/test-result/list-summary should be used instead.
@@ -180,7 +184,7 @@ func (m artifactModule) postBuildArtifactHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/tests-results [get]
-func (m artifactModule) getBuildTestsResultsHandler(c *gin.Context) {
+func (m artifactModule) getBuildTestResultListHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return

--- a/branch.go
+++ b/branch.go
@@ -19,28 +19,30 @@ type branchModule struct {
 func (m branchModule) Register(g *gin.RouterGroup) {
 	branches := g.Group("/branches")
 	{
-		branches.GET("", m.GetBranchesHandler)
-		branches.PUT("", m.PutBranchesHandler)
+		branches.GET("", m.getBrancheListHandler)
+		branches.PUT("", m.updateProjectBranchListHandler)
 	}
 
 	branch := g.Group("/branch")
 	{
-		branch.POST("", m.PostBranchHandler)
+		branch.POST("", m.createBranchHandler)
 	}
 
 	deprecated.BranchModule{}.Register(g)
 }
 
-// GetBranchesHandler godoc
+// getBrancheListHandler godoc
+// @id getBranchList
 // @summary NOT IMPLEMENTED YET
 // @tags branch
 // @success 501 "Not Implemented"
 // @router /branches [get]
-func (m branchModule) GetBranchesHandler(c *gin.Context) {
+func (m branchModule) getBrancheListHandler(c *gin.Context) {
 	c.Status(http.StatusNotImplemented)
 }
 
-// PostBranchHandler godoc
+// createBranchHandler godoc
+// @id createBranch
 // @summary Create or update branch.
 // @description It finds branch by project ID, token ID and name.
 // @description First found branch will have updated default flag.
@@ -55,7 +57,7 @@ func (m branchModule) GetBranchesHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /branch [post]
-func (m branchModule) PostBranchHandler(c *gin.Context) {
+func (m branchModule) createBranchHandler(c *gin.Context) {
 	var branch Branch
 	if err := c.ShouldBindJSON(&branch); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
@@ -89,7 +91,8 @@ func (m branchModule) PostBranchHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, existingBranch)
 }
 
-// PutBranchesHandler godoc
+// updateProjectBranchListHandler godoc
+// @id updateProjectBranchList
 // @summary Resets branches for a project
 // @description Alters the database by removing, adding and updating until the stored branches equals the input branches.
 // @tags branches
@@ -101,21 +104,21 @@ func (m branchModule) PostBranchHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /branches [put]
-func (m branchModule) PutBranchesHandler(c *gin.Context) {
+func (m branchModule) updateProjectBranchListHandler(c *gin.Context) {
 	var branches []Branch
 	if err := c.ShouldBindJSON(&branches); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
 			"One or more parameters failed to parse when reading the request body for branch object array to update.")
 		return
 	}
-	if err := m.PutBranches(branches); err != nil {
+	if err := m.putBranches(branches); err != nil {
 		ginutil.WriteDBWriteError(c, err, "Failed to update branches in database.")
 		return
 	}
 	c.JSON(http.StatusOK, branches)
 }
 
-func (m branchModule) PutBranches(branches []Branch) error {
+func (m branchModule) putBranches(branches []Branch) error {
 	return m.Database.Transaction(func(tx *gorm.DB) error {
 		var defaultBranch Branch
 		var oldDbBranches []Branch

--- a/branch.go
+++ b/branch.go
@@ -19,7 +19,7 @@ type branchModule struct {
 func (m branchModule) Register(g *gin.RouterGroup) {
 	branches := g.Group("/branches")
 	{
-		branches.GET("", m.getBrancheListHandler)
+		branches.GET("", m.getBranchListHandler)
 		branches.PUT("", m.updateProjectBranchListHandler)
 	}
 
@@ -31,13 +31,13 @@ func (m branchModule) Register(g *gin.RouterGroup) {
 	deprecated.BranchModule{}.Register(g)
 }
 
-// getBrancheListHandler godoc
+// getBranchListHandler godoc
 // @id getBranchList
 // @summary NOT IMPLEMENTED YET
 // @tags branch
 // @success 501 "Not Implemented"
 // @router /branches [get]
-func (m branchModule) getBrancheListHandler(c *gin.Context) {
+func (m branchModule) getBranchListHandler(c *gin.Context) {
 	c.Status(http.StatusNotImplemented)
 }
 

--- a/build.go
+++ b/build.go
@@ -53,15 +53,15 @@ type buildModule struct {
 func (m buildModule) Register(g *gin.RouterGroup) {
 	builds := g.Group("/builds")
 	{
-		builds.POST("/search", m.postBuildSearchHandler)
+		builds.POST("/search", m.searchBuildListHandler)
 	}
 
 	build := g.Group("/build/:buildId")
 	{
 		build.GET("", m.getBuildHandler)
-		build.PUT("", m.putBuildStatus)
-		build.POST("/log", m.postBuildLogHandler)
-		build.GET("/log", m.getLogHandler)
+		build.PUT("", m.updateBuildHandler)
+		build.POST("/log", m.createBuildLogHandler)
+		build.GET("/log", m.getBuildLogListHandler)
 		build.GET("/stream", m.streamBuildLogHandler)
 
 		artifacts := artifactModule{m.Database}
@@ -95,6 +95,7 @@ func build(buildID uint) broadcast.Broadcaster {
 }
 
 // getBuildHandler godoc
+// @id getBuild
 // @summary Finds build by build ID
 // @tags build
 // @param buildId path int true "build id"
@@ -149,18 +150,20 @@ func (m buildModule) getLogs(buildID uint) ([]Log, error) {
 	return logs, nil
 }
 
-// postBuildSearchHandler godoc
+// searchBuildListHandler godoc
+// @id searchBuildList
 // @summary NOT IMPLEMENTED YET
 // @tags build
 // @accept json
 // @produce json
 // @success 501 "Not Implemented"
 // @router /builds/search [post]
-func (m buildModule) postBuildSearchHandler(c *gin.Context) {
+func (m buildModule) searchBuildListHandler(c *gin.Context) {
 	c.Status(http.StatusNotImplemented)
 }
 
-// getLogHandler godoc
+// getBuildLogListHandler godoc
+// @id getBuildLogList
 // @summary Finds logs for build with selected build ID
 // @tags build
 // @param buildId path int true "build id"
@@ -169,7 +172,7 @@ func (m buildModule) postBuildSearchHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/log [get]
-func (m buildModule) getLogHandler(c *gin.Context) {
+func (m buildModule) getBuildLogListHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return
@@ -188,6 +191,7 @@ func (m buildModule) getLogHandler(c *gin.Context) {
 }
 
 // streamBuildLogHandler godoc
+// @id streamBuildLog
 // @summary Opens stream listener
 // @tags build
 // @param buildId path int true "build id"
@@ -217,7 +221,8 @@ func (m buildModule) streamBuildLogHandler(c *gin.Context) {
 
 }
 
-// postBuildLogHandler godoc
+// createBuildLogHandler godoc
+// @id createBuildLog
 // @summary Post a log to selected build
 // @tags build
 // @param buildId path int true "build id"
@@ -227,7 +232,7 @@ func (m buildModule) streamBuildLogHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/log [post]
-func (m buildModule) postBuildLogHandler(c *gin.Context) {
+func (m buildModule) createBuildLogHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return
@@ -261,7 +266,8 @@ func (m buildModule) postBuildLogHandler(c *gin.Context) {
 	c.Status(http.StatusCreated)
 }
 
-// putBuildStatus godoc
+// updateBuildHandler godoc
+// @id updateBuild
 // @summary Partially update specific build
 // @tags build
 // @param buildId path uint true "build id"
@@ -272,7 +278,7 @@ func (m buildModule) postBuildLogHandler(c *gin.Context) {
 // @failure 404 {object} problem.Response "Build not found"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId} [put]
-func (m buildModule) putBuildStatus(c *gin.Context) {
+func (m buildModule) updateBuildHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return

--- a/ping.go
+++ b/ping.go
@@ -7,8 +7,8 @@ import (
 type healthModule struct{}
 
 func (m healthModule) Register(g *gin.RouterGroup) {
-	g.GET("/ping", m.ping)
-	g.GET("/health", m.health)
+	g.GET("/ping", m.pingHandler)
+	g.GET("/health", m.healthHandler)
 }
 
 // DeprecatedRegister adds API health-related endpoints to a Gin-Gonic engine.
@@ -16,8 +16,8 @@ func (m healthModule) Register(g *gin.RouterGroup) {
 // Deprecated: Not part of the /api group for endpoints. Tentatively planned
 // for complete removal in v6.
 func (m healthModule) DeprecatedRegister(e *gin.Engine) {
-	e.GET("/", m.ping)
-	e.GET("/health", m.health)
+	e.GET("/", m.pingHandler)
+	e.GET("/health", m.healthHandler)
 }
 
 // Ping pongs.
@@ -25,14 +25,15 @@ type Ping struct {
 	Message string `json:"message"`
 }
 
-// ping godoc
+// pingHandler godoc
+// @id pingHandler
 // @summary Ping
 // @description You guessed it. Pong.
 // @tags health
 // @produce json
 // @success 200 {object} Ping
 // @router /ping [get]
-func (m healthModule) ping(c *gin.Context) {
+func (m healthModule) pingHandler(c *gin.Context) {
 	c.JSON(200, Ping{Message: "pong"})
 }
 
@@ -43,13 +44,14 @@ type HealthStatus struct {
 	IsHealthy bool   `example:"true" json:"isHealthy"`
 }
 
-// health godoc
+// healthHandler godoc
+// @id getHealth
 // @summary Healthcheck for the API
 // @description To be used by Kubernetes or alike.
 // @tags health
 // @produce json
 // @success 200 {object} HealthStatus
 // @router /health [get]
-func (m healthModule) health(c *gin.Context) {
+func (m healthModule) healthHandler(c *gin.Context) {
 	c.JSON(200, HealthStatus{Message: "API is healthy.", IsHealthy: true})
 }

--- a/provider.go
+++ b/provider.go
@@ -48,26 +48,27 @@ type providerModule struct {
 func (m providerModule) Register(g *gin.RouterGroup) {
 	providers := g.Group("/providers")
 	{
-		providers.GET("", m.getProvidersHandler)
-		providers.POST("/search", m.postSearchProviderHandler)
+		providers.GET("", m.getProviderListHandler)
+		providers.POST("/search", m.searchProviderListHandler)
 	}
 
 	provider := g.Group("/provider")
 	{
 		provider.GET("/:providerId", m.getProviderHandler)
-		provider.POST("", m.postProviderHandler)
-		provider.PUT("", m.putProviderHandler)
+		provider.POST("", m.createProviderHandler)
+		provider.PUT("", m.updateProviderHandler)
 	}
 }
 
-// getProvidersHandler godoc
+// getProviderListHandler godoc
+// @id getProviderList
 // @summary Returns first 100 providers
 // @tags provider
 // @success 200 {object} []Provider
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /providers [get]
-func (m providerModule) getProvidersHandler(c *gin.Context) {
+func (m providerModule) getProviderListHandler(c *gin.Context) {
 	var providers []Provider
 	err := m.Database.Limit(100).Find(&providers).Error
 	if err != nil {
@@ -78,6 +79,7 @@ func (m providerModule) getProvidersHandler(c *gin.Context) {
 }
 
 // getProviderHandler godoc
+// @id getProvider
 // @summary Returns provider with selected provider ID
 // @tags provider
 // @param providerId path int true "Provider ID"
@@ -110,7 +112,8 @@ func (m providerModule) getProviderHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, provider)
 }
 
-// postSearchProviderHandler godoc
+// searchProviderListHandler godoc
+// @id searchProviderList
 // @summary Returns arrays of providers that match to search criteria.
 // @description Returns arrays of providers that match to search criteria.
 // @description It takes into consideration name, URL, UploadURL and token ID.
@@ -123,7 +126,7 @@ func (m providerModule) getProviderHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /providers/search [post]
-func (m providerModule) postSearchProviderHandler(c *gin.Context) {
+func (m providerModule) searchProviderListHandler(c *gin.Context) {
 	var provider Provider
 	if err := c.ShouldBindJSON(&provider); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
@@ -159,7 +162,8 @@ func (m providerModule) postSearchProviderHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, providers)
 }
 
-// postProviderHandler godoc
+// createProviderHandler godoc
+// @id createProvider
 // @summary Add provider to database.
 // @description Add provider to database. Token in post object has to exists or should be empty.
 // @description Token will has to be updated Provider ID during this operation.
@@ -172,7 +176,7 @@ func (m providerModule) postSearchProviderHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /provider [post]
-func (m providerModule) postProviderHandler(c *gin.Context) {
+func (m providerModule) createProviderHandler(c *gin.Context) {
 	var provider Provider
 	if err := c.ShouldBindJSON(&provider); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
@@ -204,7 +208,8 @@ func (m providerModule) postProviderHandler(c *gin.Context) {
 	c.JSON(http.StatusCreated, provider)
 }
 
-// putProviderHandler godoc
+// updateProviderHandler godoc
+// @id updateProvider
 // @summary Put provider in database.
 // @description Creates a new provider if a match is not found.
 // @tags provider
@@ -216,7 +221,7 @@ func (m providerModule) postProviderHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /provider [put]
-func (m providerModule) putProviderHandler(c *gin.Context) {
+func (m providerModule) updateProviderHandler(c *gin.Context) {
 	var inputProvider Provider
 	if err := c.ShouldBindJSON(&inputProvider); err != nil {
 		ginutil.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")

--- a/test_result.go
+++ b/test_result.go
@@ -35,19 +35,19 @@ type TestResultListSummary struct {
 func (m buildTestResultModule) Register(r gin.IRouter) {
 	testResult := r.Group("/test-result")
 	{
-		testResult.POST("/", m.postBuildTestResultDataHandler)
+		testResult.POST("/", m.createBuildTestResultHandler)
 
-		testResult.GET("/detail", m.getBuildAllTestResultDetailsHandler)
+		testResult.GET("/detail", m.getBuildAllTestResultDetailListHandler)
 
-		testResult.GET("/summary", m.getBuildAllTestResultSummariesHandler)
+		testResult.GET("/summary", m.getBuildAllTestResultSummaryListHandler)
 		testResult.GET("/summary/:artifactId", m.getBuildTestResultSummaryHandler)
-		testResult.GET("/summary/:artifactId/detail", m.getBuildTestResultDetailsHandler)
+		testResult.GET("/summary/:artifactId/detail", m.getBuildTestResultDetailListHandler)
 
-		testResult.GET("/list-summary", m.getBuildTestResultListSummaryHandler)
+		testResult.GET("/list-summary", m.getBuildAllTestResultListSummaryHandler)
 	}
 }
 
-// postBuildTestResultDataHandler godoc
+// createBuildTestResultHandler godoc
 // @id createBuildTestResult
 // @summary Post test result data
 // @tags test-result
@@ -58,7 +58,7 @@ func (m buildTestResultModule) Register(r gin.IRouter) {
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 502 {object} problem.Response "Database unreachable or bad gateway"
 // @router /build/{buildId}/test-result [post]
-func (m buildTestResultModule) postBuildTestResultDataHandler(c *gin.Context) {
+func (m buildTestResultModule) createBuildTestResultHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return
@@ -133,7 +133,7 @@ func (m buildTestResultModule) postBuildTestResultDataHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, artifactMetadataList)
 }
 
-// getBuildAllTestResultDetailsHandler godoc
+// getBuildAllTestResultDetailListHandler godoc
 // @id getBuildAllTestResultDetailList
 // @summary Get all test result details for specified build
 // @tags test-result
@@ -142,7 +142,7 @@ func (m buildTestResultModule) postBuildTestResultDataHandler(c *gin.Context) {
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/test-result/detail [get]
-func (m buildTestResultModule) getBuildAllTestResultDetailsHandler(c *gin.Context) {
+func (m buildTestResultModule) getBuildAllTestResultDetailListHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return
@@ -164,7 +164,7 @@ func (m buildTestResultModule) getBuildAllTestResultDetailsHandler(c *gin.Contex
 	c.JSON(http.StatusOK, details)
 }
 
-// getBuildAllTestResultSummariesHandler godoc
+// getBuildAllTestResultSummaryListHandler godoc
 // @id getBuildAllTestResultSummaryList
 // @summary Get all test result summaries for specified build
 // @tags test-result
@@ -173,7 +173,7 @@ func (m buildTestResultModule) getBuildAllTestResultDetailsHandler(c *gin.Contex
 // @failure 400 {object} problem.Response "Bad Request"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/test-result/summary [get]
-func (m buildTestResultModule) getBuildAllTestResultSummariesHandler(c *gin.Context) {
+func (m buildTestResultModule) getBuildAllTestResultSummaryListHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return
@@ -232,8 +232,8 @@ func (m buildTestResultModule) getBuildTestResultSummaryHandler(c *gin.Context) 
 	c.JSON(http.StatusOK, summary)
 }
 
-// getBuildTestResultDetailsHandler godoc
-// @id getBuildTestResultDetail
+// getBuildTestResultDetailListHandler godoc
+// @id getBuildTestResultDetailList
 // @summary Get all test result details for specified test
 // @tags test-result
 // @param buildId path int true "Build ID"
@@ -242,7 +242,7 @@ func (m buildTestResultModule) getBuildTestResultSummaryHandler(c *gin.Context) 
 // @failure 400 {object} problem.Response "Bad Request"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/test-result/summary/{artifactId}/detail [get]
-func (m buildTestResultModule) getBuildTestResultDetailsHandler(c *gin.Context) {
+func (m buildTestResultModule) getBuildTestResultDetailListHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return
@@ -269,8 +269,8 @@ func (m buildTestResultModule) getBuildTestResultDetailsHandler(c *gin.Context) 
 	c.JSON(http.StatusOK, details)
 }
 
-// getBuildTestResultListSummaryHandler godoc
-// @id getBuildAllTestResultSummary
+// getBuildAllTestResultListSummaryHandler godoc
+// @id getBuildAllTestResultListSummary
 // @summary Get test result list summary of all tests for specified build
 // @tags test-result
 // @param buildId path int true "Build ID"
@@ -278,7 +278,7 @@ func (m buildTestResultModule) getBuildTestResultDetailsHandler(c *gin.Context) 
 // @failure 400 {object} problem.Response "Bad Request"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/test-result/list-summary [get]
-func (m buildTestResultModule) getBuildTestResultListSummaryHandler(c *gin.Context) {
+func (m buildTestResultModule) getBuildAllTestResultListSummaryHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {
 		return

--- a/test_result.go
+++ b/test_result.go
@@ -48,6 +48,7 @@ func (m buildTestResultModule) Register(r gin.IRouter) {
 }
 
 // postBuildTestResultDataHandler godoc
+// @id createBuildTestResult
 // @summary Post test result data
 // @tags test-result
 // @accept multipart/form-data
@@ -133,6 +134,7 @@ func (m buildTestResultModule) postBuildTestResultDataHandler(c *gin.Context) {
 }
 
 // getBuildAllTestResultDetailsHandler godoc
+// @id getBuildAllTestResultDetailList
 // @summary Get all test result details for specified build
 // @tags test-result
 // @param buildId path int true "Build ID"
@@ -163,6 +165,7 @@ func (m buildTestResultModule) getBuildAllTestResultDetailsHandler(c *gin.Contex
 }
 
 // getBuildAllTestResultSummariesHandler godoc
+// @id getBuildAllTestResultSummaryList
 // @summary Get all test result summaries for specified build
 // @tags test-result
 // @param buildId path int true "Build ID"
@@ -193,6 +196,7 @@ func (m buildTestResultModule) getBuildAllTestResultSummariesHandler(c *gin.Cont
 }
 
 // getBuildTestResultSummaryHandler godoc
+// @id getBuildTestResultSummary
 // @summary Get test result summary for specified test
 // @tags test-result
 // @param buildId path int true "Build ID"
@@ -229,6 +233,7 @@ func (m buildTestResultModule) getBuildTestResultSummaryHandler(c *gin.Context) 
 }
 
 // getBuildTestResultDetailsHandler godoc
+// @id getBuildTestResultDetail
 // @summary Get all test result details for specified test
 // @tags test-result
 // @param buildId path int true "Build ID"
@@ -265,6 +270,7 @@ func (m buildTestResultModule) getBuildTestResultDetailsHandler(c *gin.Context) 
 }
 
 // getBuildTestResultListSummaryHandler godoc
+// @id getBuildAllTestResultSummary
 // @summary Get test result list summary of all tests for specified build
 // @tags test-result
 // @param buildId path int true "Build ID"

--- a/token.go
+++ b/token.go
@@ -19,26 +19,27 @@ type tokenModule struct {
 func (m tokenModule) Register(g *gin.RouterGroup) {
 	tokens := g.Group("/tokens")
 	{
-		tokens.GET("", m.getTokensHandler)
-		tokens.POST("/search", m.postSearchTokenHandler)
+		tokens.GET("", m.getTokenListHandler)
+		tokens.POST("/search", m.searchTokenListHandler)
 	}
 
 	token := g.Group("/token")
 	{
 		token.GET("/:tokenId", m.getTokenHandler)
-		token.POST("", m.postTokenHandler)
-		token.PUT("", m.putTokenHandler)
+		token.POST("", m.createTokenHandler)
+		token.PUT("", m.updateTokenHandler)
 	}
 }
 
-// getTokensHandler godoc
+// getTokenListHandler godoc
+// @id getTokenList
 // @summary Returns first 100 tokens
 // @tags token
 // @success 200 {object} []Token
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /tokens [get]
-func (m tokenModule) getTokensHandler(c *gin.Context) {
+func (m tokenModule) getTokenListHandler(c *gin.Context) {
 
 	var tokens []Token
 	err := m.Database.Limit(100).Find(&tokens).Error
@@ -51,6 +52,7 @@ func (m tokenModule) getTokensHandler(c *gin.Context) {
 }
 
 // getTokenHandler godoc
+// @id getToken
 // @summary Returns token with selected token ID
 // @tags token
 // @param tokenId path int true "Token ID"
@@ -80,7 +82,8 @@ func (m tokenModule) getTokenHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, token)
 }
 
-// postSearchTokenHandler godoc
+// searchTokenListHandler godoc
+// @id searchTokenList
 // @summary Returns arrays of tokens that match to search criteria.
 // @description Returns arrays of tokens that match to search criteria.
 // @description It takes into consideration only token string and user name.
@@ -93,7 +96,7 @@ func (m tokenModule) getTokenHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /tokens/search [post]
-func (m tokenModule) postSearchTokenHandler(c *gin.Context) {
+func (m tokenModule) searchTokenListHandler(c *gin.Context) {
 	var token Token
 	if err := c.ShouldBindJSON(&token); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
@@ -123,7 +126,8 @@ type TokenWithProviderID struct {
 	ProviderID uint `json:"providerId"`
 }
 
-// postTokenHandler godoc
+// createTokenHandler godoc
+// @id createToken
 // @summary Add token to database.
 // @description Add token to database. Provider in post object has to exists or should be empty.
 // @tags token
@@ -136,7 +140,7 @@ type TokenWithProviderID struct {
 // @failure 404 {object} problem.Response "Referenced provider not found"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /token [post]
-func (m tokenModule) postTokenHandler(c *gin.Context) {
+func (m tokenModule) createTokenHandler(c *gin.Context) {
 	var (
 		tokenWithProviderID TokenWithProviderID
 		token               *Token
@@ -182,7 +186,8 @@ func (m tokenModule) postTokenHandler(c *gin.Context) {
 	c.JSON(http.StatusCreated, token)
 }
 
-// postTokenHandler godoc
+// updateTokenHandler godoc
+// @id updateToken
 // @summary Put token in database.
 // @description Creates a new token if a match is not found.
 // @tags token
@@ -194,7 +199,7 @@ func (m tokenModule) postTokenHandler(c *gin.Context) {
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /token [put]
-func (m tokenModule) putTokenHandler(c *gin.Context) {
+func (m tokenModule) updateTokenHandler(c *gin.Context) {
 	var inputToken Token
 	if err := c.ShouldBindJSON(&inputToken); err != nil {
 		ginutil.WriteInvalidBindError(c, err, "One or more parameters failed to parse when reading the request body.")

--- a/version.go
+++ b/version.go
@@ -22,6 +22,7 @@ func loadEmbeddedVersionFile() error {
 }
 
 // getVersionHandler godoc
+// @id getVersion
 // @summary Returns the version of this API
 // @tags meta
 // @success 200 {object} app.Version


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added Swaggo `// @id` comment field, which adds Swagger operation IDs to the endpoints.
- Changed name of Gin handler methods to correlate with the new Swagger op IDs

## Motivation

Closes #67
