### PR TITLE
Fixed N+1 Build and TestResult fetch issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   ID has not been shown to have any benefits. Please refer to the
   `GET /project/{projectId}` endpoint instead. (#75)
 
+- Added `TestResultListSummary` field to `Build` database model. This should
+  allow us to avoid `N+1 Select` in wharf-api. (#80)
+
+- Changed to preload `TestResultSummaries` field of `Build` database
+  model. (#80)
+
 ## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   ID has not been shown to have any benefits. Please refer to the
   `GET /project/{projectId}` endpoint instead. (#75)
 
-- Added `TestResultListSummary` field to `Build` database model. This should
-  allow us to avoid `N+1 Select` in wharf-api. (#80)
+- Added `TestResultListSummary` field to `Build` database model. This allows you
+  to avoid `N+1` HTTP requests when listing builds to show test summaries. (#80)
 
 - Changed to preload `TestResultSummaries` field of `Build` database
   model. (#80)

--- a/branch.go
+++ b/branch.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/iver-wharf/wharf-api/internal/deprecated"
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 
 	"github.com/gin-gonic/gin"

--- a/build.go
+++ b/build.go
@@ -132,7 +132,7 @@ func (m buildModule) getBuild(buildID uint) (Build, error) {
 	var build Build
 	if err := m.Database.
 		Where(&Build{BuildID: buildID}).
-    Preload(database.BuildFields.TestResultSummaries).
+		Preload(database.BuildFields.TestResultSummaries).
 		Preload(database.BuildFields.Params).
 		First(&build).
 		Error; err != nil {

--- a/database_models.go
+++ b/database_models.go
@@ -106,10 +106,10 @@ type Branch struct {
 }
 
 const (
-	buildColumnBuildID            = "build_id"
 	buildAssocParams              = "Params"
-	buildColumnName               = "name"
 	buildAssocTestResultSummaries = "TestResultSummaries"
+	buildColumnBuildID            = "build_id"
+	buildColumnName               = "name"
 )
 
 var buildJSONToColumns = map[string]string{

--- a/database_models.go
+++ b/database_models.go
@@ -106,9 +106,10 @@ type Branch struct {
 }
 
 const (
-	buildColumnBuildID = "build_id"
-	buildAssocParams   = "Params"
-	buildColumnName    = "name"
+	buildColumnBuildID            = "build_id"
+	buildAssocParams              = "Params"
+	buildColumnName               = "name"
+	buildAssocTestResultSummaries = "TestResultSummaries"
 )
 
 var buildJSONToColumns = map[string]string{
@@ -138,6 +139,8 @@ type Build struct {
 	Params              []BuildParam        `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"params"`
 	IsInvalid           bool                `gorm:"not null;default:false" json:"isInvalid"`
 	TestResultSummaries []TestResultSummary `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE" json:"testResultSummaries"`
+	// TestResultListSummary is populated manually after fetching from the database.
+	TestResultListSummary TestResultListSummary `gorm:"-" json:"testResultListSummary"`
 	// Status is populated when marshalled via MarshalJSON
 	Status string `gorm:"-" json:"status"`
 }

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -47,7 +47,7 @@ var ProviderFields = struct {
 // used to authenticate.
 type Provider struct {
 	ProviderID uint   `gorm:"primaryKey"`
-	Name       string `gorm:"size:20;not null"enum:"azuredevops,gitlab,github"`
+	Name       string `gorm:"size:20;not null" enum:"azuredevops,gitlab,github"`
 	URL        string `gorm:"size:500;not null"`
 	UploadURL  string `gorm:"size:500"`
 	TokenID    uint   `gorm:"nullable;default:NULL;index:provider_idx_token_id"`
@@ -129,7 +129,7 @@ var BranchFields = struct {
 // BranchColumns holds the DB column names for each field.
 // Useful in GORM .Order() statements to order the results based on a specific
 // column, which does not support the regular Go field names.
-var BranchColumns = struct{
+var BranchColumns = struct {
 	BranchID string
 }{
 	BranchID: "branch_id",
@@ -151,9 +151,11 @@ type Branch struct {
 // Useful in GORM .Where() statements to only select certain fields or in GORM
 // Preload statements to select the correct field to preload.
 var BuildFields = struct {
-	Params string
+	Params              string
+	TestResultSummaries string
 }{
-	Params: "Params",
+	Params:              "Params",
+	TestResultSummaries: "TestResultSummaries",
 }
 
 // BuildColumns holds the DB column names for each field.
@@ -190,7 +192,7 @@ type Build struct {
 	StartedOn           null.Time           `gorm:"nullable;default:NULL"`
 	CompletedOn         null.Time           `gorm:"nullable;default:NULL"`
 	GitBranch           string              `gorm:"size:300;default:'';not null"`
-	Environment         null.String         `gorm:"nullable;size:40"swaggertype:"string"`
+	Environment         null.String         `gorm:"nullable;size:40" swaggertype:"string"`
 	Stage               string              `gorm:"size:40;default:'';not null"`
 	Params              []BuildParam        `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	IsInvalid           bool                `gorm:"not null;default:false"`

--- a/project.go
+++ b/project.go
@@ -696,12 +696,20 @@ func (m projectModule) getBuilds(projectID uint, limit int, offset int, orderByS
 	var builds []Build
 	var query = m.Database.
 		Where(&Build{ProjectID: projectID}).
+		Preload(buildAssocTestResultSummaries).
 		Limit(limit).
 		Offset(offset)
 	query = orderby.ApplyAllToGormQuery(query, orderBySlice, defaultGetBuildsOrderBy)
 	if err := query.Find(&builds).Error; err != nil {
 		return []Build{}, err
 	}
+
+	for i := range builds {
+		if err := populateTestResultListSummary(m.Database, builds[i].BuildID, &builds[i].TestResultListSummary); err != nil {
+			return []Build{}, err
+		}
+	}
+
 	return builds, nil
 }
 

--- a/project.go
+++ b/project.go
@@ -705,9 +705,11 @@ func (m projectModule) getBuilds(projectID uint, limit int, offset int, orderByS
 	}
 
 	for i := range builds {
-		if err := populateTestResultListSummary(m.Database, builds[i].BuildID, &builds[i].TestResultListSummary); err != nil {
+		listSummary, err := getTestResultListSummary(m.Database, builds[i].BuildID)
+		if err != nil {
 			return []Build{}, err
 		}
+		builds[i].TestResultListSummary = listSummary
 	}
 
 	return builds, nil

--- a/project.go
+++ b/project.go
@@ -716,7 +716,7 @@ func (m projectModule) getBuilds(projectID uint, limit int, offset int, orderByS
 	var builds []Build
 	var query = m.Database.
 		Where(&Build{ProjectID: projectID}).
-		Preload(buildAssocTestResultSummaries).
+		Preload(database.BuildFields.TestResultSummaries).
 		Limit(limit).
 		Offset(offset)
 	query = orderby.ApplyAllToGormQuery(query, orderBySlice, defaultGetBuildsOrderBy)


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Added `Build.TestResultListSummary` field.
This field is manually populated when fetching a `Build`, using the function `populateTestResultListSummary` located in `build.go`.

Changed so `Build.TestResultSummaries` is preloaded in `buildModule.getBuild` and `projectModule.getBuilds`.

## Motivation

One big part of the test result handling rework (#43) was to fix N+1 Select issue(s) in [wharf-web](https://github.com/iver-wharf/wharf-web), but I seem to have mucked up the ability to do that. This should fix that.

## Note

I wasn't able to think of a way to populate `Build.TestResultListSummary` in the same DB request as getting them (`buildModule.getBuild` and `projectModule.getBuilds`). We could add `TestResultListSummary` to the database, but since it's just a calculated value I'm not sure about if that's the way we should do it.