### PR TITLE
Removed Provider.UploadURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v4.3.0 (WIP)
+## v5.0.0 (WIP)
 
 - Fixed bug where unable to delete a Project without first deleting all child
   objects. (#64)
@@ -63,6 +63,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Deprecated endpoint `GET /branch/{branchId}`. Getting a single branch by its
   ID has not been shown to have any benefits. Please refer to the
   `GET /project/{projectId}` endpoint instead. (#75)
+
+- Removed `Provider.UploadURL` and all references to it, as it was unused. (#82)
+
+- Removed DB column `provider.upload_url`, as it was unused. (#82)
 
 ## v4.2.0 (2021-09-10)
 

--- a/database_models.go
+++ b/database_models.go
@@ -26,10 +26,9 @@ import (
 // consistent we add it to both referencing fields.
 
 const (
-	providerFieldName      = "Name"
-	providerFieldURL       = "URL"
-	providerFieldUploadURL = "UploadURL"
-	providerFieldTokenID   = "TokenID"
+	providerFieldName    = "Name"
+	providerFieldURL     = "URL"
+	providerFieldTokenID = "TokenID"
 )
 
 // Provider holds metadata about a connection to a remote provider. Some of
@@ -39,7 +38,6 @@ type Provider struct {
 	ProviderID uint   `gorm:"primaryKey" json:"providerId"`
 	Name       string `gorm:"size:20;not null" json:"name" enum:"azuredevops,gitlab,github"`
 	URL        string `gorm:"size:500;not null" json:"url"`
-	UploadURL  string `gorm:"size:500" json:"uploadUrl"`
 	TokenID    uint   `gorm:"nullable;default:NULL;index:provider_idx_token_id" json:"tokenId"`
 	Token      *Token `gorm:"foreignKey:TokenID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT" json:"-"`
 }

--- a/migrations.go
+++ b/migrations.go
@@ -60,9 +60,15 @@ func runDatabaseMigrations(db *gorm.DB) error {
 		return err
 	}
 
-	// since v3.1.0, the token.provider_id column was removed as it induced a
-	// circular dependency between the token and provider tables
-	if err := dropOldColumn(db, &Token{}, "provider_id"); err != nil {
+	oldColumns := []columnToDrop{
+		// since v3.1.0, the token.provider_id column was removed as it induced a
+		// circular dependency between the token and provider tables
+		{&Token{}, "provider_id"},
+		// Since v4.3.0, the Provider.upload_url column was removed as it was unused.
+		{&Provider{}, "upload_url"},
+	}
+
+	if err := dropOldColumns(db, oldColumns); err != nil {
 		return err
 	}
 
@@ -105,6 +111,21 @@ func dropOldConstraint(db *gorm.DB, table string, constraintName string) error {
 			WithString("table", table).
 			WithString("constraint", constraintName).
 			Message("No old constraint to remove.")
+	}
+	return nil
+}
+
+type columnToDrop struct {
+	model      interface{}
+	columnName string
+}
+
+func dropOldColumns(db *gorm.DB, columns []columnToDrop) error {
+	log.Debug().WithInt("columns", len(columns)).Message("Dropping old columns.")
+	for _, dbColumn := range columns {
+		if err := dropOldColumn(db, dbColumn.model, dbColumn.columnName); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/migrations.go
+++ b/migrations.go
@@ -64,7 +64,8 @@ func runDatabaseMigrations(db *gorm.DB) error {
 		// since v3.1.0, the token.provider_id column was removed as it induced a
 		// circular dependency between the token and provider tables
 		{&Token{}, "provider_id"},
-		// Since v4.3.0, the Provider.upload_url column was removed as it was unused.
+		// Since v5.0.0, the Provider.upload_url column was removed as it was
+		// unused.
 		{&Provider{}, "upload_url"},
 	}
 

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -31,15 +31,13 @@ import (
 // Useful in GORM .Where() statements to only select certain fields or in GORM
 // Preload statements to select the correct field to preload.
 var ProviderFields = struct {
-	Name      string
-	URL       string
-	UploadURL string
-	TokenID   string
+	Name    string
+	URL     string
+	TokenID string
 }{
-	Name:      "Name",
-	URL:       "URL",
-	UploadURL: "UploadURL",
-	TokenID:   "TokenID",
+	Name:    "Name",
+	URL:     "URL",
+	TokenID: "TokenID",
 }
 
 // Provider holds metadata about a connection to a remote provider. Some of
@@ -49,7 +47,6 @@ type Provider struct {
 	ProviderID uint   `gorm:"primaryKey"`
 	Name       string `gorm:"size:20;not null" enum:"azuredevops,gitlab,github"`
 	URL        string `gorm:"size:500;not null"`
-	UploadURL  string `gorm:"size:500"`
 	TokenID    uint   `gorm:"nullable;default:NULL;index:provider_idx_token_id"`
 	Token      *Token `gorm:"foreignKey:TokenID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT"`
 }

--- a/provider.go
+++ b/provider.go
@@ -113,7 +113,7 @@ func (m providerModule) getProviderHandler(c *gin.Context) {
 // postSearchProviderHandler godoc
 // @summary Returns arrays of providers that match to search criteria.
 // @description Returns arrays of providers that match to search criteria.
-// @description It takes into consideration name, URL, UploadURL and token ID.
+// @description It takes into consideration name, URL and token ID.
 // @tags provider
 // @accept json
 // @produce json
@@ -134,24 +134,24 @@ func (m providerModule) postSearchProviderHandler(c *gin.Context) {
 	var providers []Provider
 	if provider.TokenID != 0 {
 		err := m.Database.
-			Where(&provider, providerFieldName, providerFieldURL, providerFieldUploadURL, providerFieldTokenID).
+			Where(&provider, providerFieldName, providerFieldURL, providerFieldTokenID).
 			Find(&providers).
 			Error
 		if err != nil {
 			ginutil.WriteDBReadError(c, err, fmt.Sprintf(
-				"Failed fetching list of providers with name %q, URL %q, upload URL %q, and with token ID %d from database.",
-				provider.Name, provider.URL, provider.UploadURL, provider.TokenID))
+				"Failed fetching list of providers with name %q, URL %q, and token ID %d from database.",
+				provider.Name, provider.URL, provider.TokenID))
 			return
 		}
 	} else {
 		err := m.Database.
-			Where(&provider, providerFieldName, providerFieldURL, providerFieldUploadURL).
+			Where(&provider, providerFieldName, providerFieldURL).
 			Find(&providers).
 			Error
 		if err != nil {
 			ginutil.WriteDBReadError(c, err, fmt.Sprintf(
-				"Failed fetching list of providers with name %q, URL %q, and with upload URL %q from database.",
-				provider.Name, provider.URL, provider.UploadURL))
+				"Failed fetching list of providers with name %q, and URL %q from database.",
+				provider.Name, provider.URL))
 			return
 		}
 	}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Removed field `Provider.UploadURL` and all references to it.
Added migration to remove DB column `provider.upload_url`

## Motivation

This field was unused and mostly lead to confusion.

## Notes

Tried building wharf-web after the change but it wouldn't pass because `MainProvider.uploadUrl` from the previous swag definitions was used at `src/app/providers/providers.service.ts:L50`.

The change of `id` -> `Id` from #76 also causes the build to fail because of the auto-generated names for the endpoint functions, so I believe a MAJOR version bump is in order.

--
Closes #56.