### PR TITLE
Added config for local dev purpose

### DIFF
--- a/wharf-api-config.yml
+++ b/wharf-api-config.yml
@@ -1,0 +1,25 @@
+# See config.go for reference on all config options
+
+instanceId: local
+
+db:
+  name: wharf
+  host: localhost
+  port: 5432
+  username: postgres
+  # This password correlates to the one used in
+  # https://github.com/iver-wharf/wharf-docker-compose
+  # It is not a leaked password :)
+  password: OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
+  log: true
+
+mq:
+  enabled: false
+
+ci:
+  mockTriggerResponse: true
+
+http:
+  bindAddress: :5001
+  cors:
+    allowAllOrigins: true


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `wharf-api-config.yml`

## Motivation

Using the same values as from <https://github.com/iver-wharf/wharf-docker-compose>, but laid out in the YAML format that Wharf supports.

This makes local development easier, as you can run `make serve`, `go run .`, or run the wharf-api with debugging through your IDE. Much simpler than advertised in <https://iver-wharf.github.io/#/development/debugging-in-goland>

Best thing is that you don't have to rebuild the docker image just to try out your new changes, as `go run .` is much faster than `docker build`.

Will apply similar configs to the other repos if this gets merged.