### PR TITLE
Added support for Sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea
 /node_modules/
 /package-lock.json
+*.db

--- a/database.go
+++ b/database.go
@@ -1,17 +1,54 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/iver-wharf/wharf-core/pkg/gormutil"
 	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 	"gorm.io/gorm/schema"
 )
 
+var errUnsupportedDBDriver = errors.New("unsupported database driver")
+
+func dbDriverSupportsForeignKeyConstraints(driver DBDriver) bool {
+	switch driver {
+	case DBDriverSqlite:
+		return false
+	default:
+		return true
+	}
+}
+
 func openDatabase(config DBConfig) (*gorm.DB, error) {
+	log.Info().WithString("driver", string(config.Driver)).Message("Connecting to database.")
+
+	switch config.Driver {
+	case DBDriverPostgres:
+		return openDatabasePostgres(config)
+	case DBDriverSqlite:
+		return openDatabaseSqlite(config)
+	default:
+		return nil, errUnsupportedDBDriver
+	}
+}
+
+func openDatabaseSqlite(config DBConfig) (*gorm.DB, error) {
+	if err := os.MkdirAll(filepath.Dir(config.Path), os.ModePerm); err != nil {
+		return nil, fmt.Errorf("create directories for sqlite file: %w", err)
+	}
+
+	var gormConfig = getGormConfig(config)
+	return gorm.Open(sqlite.Open(config.Path), &gormConfig)
+}
+
+func openDatabasePostgres(config DBConfig) (*gorm.DB, error) {
 	const retryDelay = 2 * time.Second
 	const maxAttempts = 3
 	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=postgres sslmode=disable",
@@ -20,13 +57,7 @@ func openDatabase(config DBConfig) (*gorm.DB, error) {
 		config.Username,
 		config.Password)
 
-	var gormConfig = gorm.Config{
-		NamingStrategy: schema.NamingStrategy{
-			SingularTable: true,
-		},
-		Logger: getLogger(config),
-	}
-
+	var gormConfig = getGormConfig(config)
 	var db *gorm.DB
 	var err error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
@@ -83,6 +114,15 @@ func openDatabase(config DBConfig) (*gorm.DB, error) {
 
 	err = sqlDb.Ping()
 	return db, err
+}
+
+func getGormConfig(config DBConfig) gorm.Config {
+	return gorm.Config{
+		NamingStrategy: schema.NamingStrategy{
+			SingularTable: true,
+		},
+		Logger: getLogger(config),
+	}
 }
 
 func getLogger(config DBConfig) logger.Interface {

--- a/go.mod
+++ b/go.mod
@@ -19,5 +19,6 @@ require (
 	github.com/swaggo/swag v1.7.1
 	gopkg.in/guregu/null.v4 v4.0.0
 	gorm.io/driver/postgres v1.1.1
+	gorm.io/driver/sqlite v1.1.5
 	gorm.io/gorm v1.21.15
 )

--- a/go.sum
+++ b/go.sum
@@ -349,6 +349,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-sqlite3 v1.14.8 h1:gDp86IdQsN/xWjIEmr9MF6o9mpksUgh0fu+9ByFxzIU=
+github.com/mattn/go-sqlite3 v1.14.8/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -746,6 +748,8 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gorm.io/driver/postgres v1.1.0/go.mod h1:hXQIwafeRjJvUm+OMxcFWyswJ/vevcpPLlGocwAwuqw=
 gorm.io/driver/postgres v1.1.1 h1:tWLmqYCyaoh89fi7DhM6QggujrOnmfo3H98AzgNAAu0=
 gorm.io/driver/postgres v1.1.1/go.mod h1:tpe2xN7aCst1NUdYyWQyxPtnHC+Zfp6NEux9PXD1OU0=
+gorm.io/driver/sqlite v1.1.5 h1:JU8G59VyKu1x1RMQgjefQnkZjDe9wHc1kARDZPu5dZs=
+gorm.io/driver/sqlite v1.1.5/go.mod h1:NpaYMcVKEh6vLJ47VP6T7Weieu4H1Drs3dGD/K6GrGc=
 gorm.io/gorm v1.21.9/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 gorm.io/gorm v1.21.11/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 gorm.io/gorm v1.21.15 h1:gAyaDoPw0lCyrSFWhBlahbUA1U4P5RViC1uIqoB+1Rk=

--- a/main.go
+++ b/main.go
@@ -64,11 +64,14 @@ func main() {
 
 	db, err := openDatabase(config.DB)
 	if err != nil {
-		log.Error().WithError(err).Message("Database error")
+		log.Error().
+			WithString("driver", string(config.DB.Driver)).
+			WithError(err).
+			Message("Database error")
 		os.Exit(2)
 	}
 
-	err = runDatabaseMigrations(db)
+	err = runDatabaseMigrations(db, config.DB.Driver)
 	if err != nil {
 		log.Error().WithError(err).Message("Migration error")
 		os.Exit(3)

--- a/wharf-api-config.yml
+++ b/wharf-api-config.yml
@@ -3,15 +3,19 @@
 instanceId: local
 
 db:
+  driver: sqlite
   name: wharf
-  host: localhost
-  port: 5432
-  username: postgres
-  # This password correlates to the one used in
-  # https://github.com/iver-wharf/wharf-docker-compose
-  # It is not a leaked password :)
-  password: OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
   log: true
+
+  ## To connect to DB from iver-wharf/wharf-docker-compose, use this:
+  #driver: postgres
+  #host: localhost
+  #port: 5432
+  #username: postgres
+  ## This password correlates to the one used in
+  ## https://github.com/iver-wharf/wharf-docker-compose
+  ## It is not a leaked password :)
+  #password: OL2AEn6lgj6ekajgKJIOanefgegnksngpoetPIEQjhankf7412
 
 mq:
   enabled: false


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added dependency on `gorm.io/driver/sqlite`

- Added configs:

  - `WHARF_DB_DRIVER` / `db.driver`: Select driver, defaults to `postgres`
  - `WHARF_DB_PATH` / `db.path`: Path to database file, if using `sqlite` as driver, defaults to `wharf-api.db`

- Disabled foreign key constraint migrations when using `sqlite` as Sqlite does not support it.

## Motivation

Makes local development easier by not requiring a local database to be set up.

One big limitation is that it requires `gcc` to compile. Could someone with Windows please check if you fail to compile wharf-api out of the box by running `go build`? Perhaps @fredx30?

Another limitation is that it requires `GCO_ENABLED=1` for Sqlite to work, while we use `GCO_ENABLED=0` in our Docker build. This can be looked into, but I don't have the energy right now and as we don't strictly need it atm I'm just deferring users in the CHANGELOG.md to create an issue on it on demand.

The docker image still compiles just fine. It runs with postgres as driver just fine as well, but if you run the compiled Docker image with environment variable `WHARF_DB_DRIVER=sqlite` then the following error appears:

```console
Sep-30 18:40+0200 [INFO |WHARF|src/database.go:30     ] Connecting to database.  driver=sqlite
Sep-30 18:40+0200 [ERROR|GORM|…m@v1.21.15/gorm.go:202] failed to initialize database, got error Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
Sep-30 18:40+0200 [ERROR|WHARF|src/main.go:67         ] Database error  driver=sqlite  error=`Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub` (*errors.errorString)
```
