### PR TITLE
Added `wharf-api` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /node_modules/
 /package-lock.json
 *.db
+
+/wharf-api
+/wharf-api.exe


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `/wharf-api` and `/wharf-api.exe` to `.gitignore`

## Motivation

Doing `make` or `go build` will produce this file. No need to accidentally push it to the repo
