### PR TITLE
Added swaggo docs param projectId to updateProjectHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added Swagger operation IDs to all endpoints. This has no effect on the API's
   behavior, but affects code generators. (#79)
 
+- Fixed bug where projects created using the deprecated `PUT /project` endpoint
+  would have set a null `ProviderID` in the database. (#96)
+
 ## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.

--- a/internal/deprecated/project.go
+++ b/internal/deprecated/project.go
@@ -98,7 +98,7 @@ func (m ProjectModule) updateProjectHandler(c *gin.Context) {
 				Description:     reqProjectUpdate.Description,
 				AvatarURL:       reqProjectUpdate.AvatarURL,
 				TokenID:         reqProjectUpdate.TokenID,
-				ProviderID:      reqProjectUpdate.ProjectID,
+				ProviderID:      reqProjectUpdate.ProviderID,
 				BuildDefinition: reqProjectUpdate.BuildDefinition,
 				GitURL:          reqProjectUpdate.GitURL,
 			}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Added swaggo docs param `projectId` to `updateProjectHandler`.

## Motivation

When generating the rest clients for wharf-web it failed because the `projectId` param was not defined for the resulting function, this fixes that.