### PR TITLE
Migrate columns to `NOT NULL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,23 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added Swagger attribute `minimum` to all ID path parameters, response bodies,
   and request bodies, as we do not support negative values there. (#98)
 
+- Changed a lot of database columns to be `NOT NULL` where wharf-api already
+  didn't support null/nil values. Migration steps have been added so any
+  potential null values will be changed to empty strings or zeroes.
+  The updated columns are: (#100)
+
+  - `artifact.file_name`
+  - `build_param.value`
+  - `param.default_value`
+  - `param.value`
+  - `project.avatar_url`
+  - `project.build_definition`
+  - `project.description`
+  - `project.git_url`
+  - `project.group_name`
+  - `test_result_summary.file_name`
+  - `token.user_name`
+
 ## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.

--- a/migrations.go
+++ b/migrations.go
@@ -29,6 +29,8 @@ func runDatabaseMigrations(db *gorm.DB, driver DBDriver) error {
 				" We advice against using this driver for production!")
 	}
 
+	// since v5.0.0, all columns that were not nil'able in the GORM models
+	// has been migrated to not be nullable in the database either.
 	if err := migrateWharfColumnsToNotNull(driver, db); err != nil {
 		return err
 	}

--- a/migrations.go
+++ b/migrations.go
@@ -201,7 +201,7 @@ func migrateWharfColumnsToNotNull(driver DBDriver, db *gorm.DB) error {
 	if err := migrateColumnsToNotNull(driver, db, &database.Token{},
 		database.TokenFields.UserName,
 	); err != nil {
-		return fmt.Errorf("migrating columns to not null for project: %w", err)
+		return fmt.Errorf("migrating columns to not null for token: %w", err)
 	}
 
 	if err := migrateColumnsToNotNull(driver, db, &database.Project{},
@@ -230,7 +230,7 @@ func migrateWharfColumnsToNotNull(driver DBDriver, db *gorm.DB) error {
 	if err := migrateColumnsToNotNull(driver, db, &database.Artifact{},
 		database.ArtifactFields.FileName,
 	); err != nil {
-		return fmt.Errorf("migrating columns to not null for param: %w", err)
+		return fmt.Errorf("migrating columns to not null for artifact: %w", err)
 	}
 
 	if err := migrateColumnsToNotNull(driver, db, &database.TestResultSummary{},
@@ -307,7 +307,7 @@ func migrateColumnToNotNull(driver DBDriver, db *gorm.DB, model interface{}, wan
 
 	if err := db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(model).Where(want.DBName, nil).Update(want.DBName, defaultValue).Error; err != nil {
-			return fmt.Errorf("set all to zero where %q is null: %w", want.DBName, err)
+			return fmt.Errorf("set all to default value where %q is null: %w", want.DBName, err)
 		}
 
 		switch driver {

--- a/migrations.go
+++ b/migrations.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
 )
 
 func runDatabaseMigrations(db *gorm.DB, driver DBDriver) error {
@@ -29,45 +29,9 @@ func runDatabaseMigrations(db *gorm.DB, driver DBDriver) error {
 				" We advice against using this driver for production!")
 	}
 
-	types, err := db.Migrator().ColumnTypes(&database.Project{})
-	fmt.Println("err:", err)
-	fmt.Printf("Types: %#v\n", types)
-	for _, columnType := range types {
-		var (
-			nullableStr string = "<nil>"
-			lengthStr   string = "<nil>"
-		)
-		if nullable, ok := columnType.Nullable(); ok {
-			nullableStr = strconv.FormatBool(nullable)
-		}
-		if length, ok := columnType.Length(); ok {
-			lengthStr = strconv.FormatInt(length, 10)
-		}
-		log.Info().
-			WithString("dbTypeName", columnType.DatabaseTypeName()).
-			WithString("name", columnType.Name()).
-			WithString("nullable", nullableStr).
-			WithString("length", lengthStr).
-			Message("Column type")
-	}
-	stmt := db.Model(&database.Project{}).Statement
-	if err := stmt.Parse(&database.Project{}); err != nil {
+	if err := migrateWharfColumnsToNotNull(driver, db); err != nil {
 		return err
 	}
-	for _, field := range stmt.Schema.Fields {
-		log.Info().
-			WithString("name", field.Name).
-			WithBool("notNull", field.NotNull).
-			WithInt("size", field.Size).
-			Message("Field type")
-	}
-	//if err := db.Migrator().AlterColumn(&database.Project{}, "Description"); err != nil {
-	//	return err
-	//}
-	//if err := db.Migrator().AlterColumn(&database.Project{}, &schema.Field{}); err != nil {
-	//	db.Model(&database.Project{}).Statement.Schema.Fields
-	//	return err
-	//}
 
 	oldColumns := []columnToDrop{
 		// since v3.1.0, the token.provider_id column was removed as it induced a
@@ -91,20 +55,6 @@ func runDatabaseMigrations(db *gorm.DB, driver DBDriver) error {
 
 	return dropOldIndices(db, oldIndices)
 }
-
-//func myAlterColumn(m gorm.Migrator, value interface{}, field string) error {
-//	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
-//		if field := stmt.Schema.LookUpField(field); field != nil {
-//			fileType := clause.Expr{SQL: m.DataTypeOf(field)}
-//			return m.DB.Exec(
-//				"ALTER TABLE ? ALTER COLUMN ? TYPE ?",
-//				m.CurrentTable(stmt), clause.Column{Name: field.DBName}, fileType,
-//			).Error
-//
-//		}
-//		return fmt.Errorf("failed to look up field with name: %s", field)
-//	})
-//}
 
 func migrateConstraints(db *gorm.DB, tables []interface{}) error {
 	if err := db.Transaction(func(tx *gorm.DB) error {
@@ -245,4 +195,178 @@ func dropOldIndex(db *gorm.DB, table string, indexName string) error {
 			Message("No old index to remove.")
 	}
 	return nil
+}
+
+func migrateWharfColumnsToNotNull(driver DBDriver, db *gorm.DB) error {
+	if err := migrateColumnsToNotNull(driver, db, &database.Token{},
+		database.TokenFields.UserName,
+	); err != nil {
+		return fmt.Errorf("migrating columns to not null for project: %w", err)
+	}
+
+	if err := migrateColumnsToNotNull(driver, db, &database.Project{},
+		database.ProjectFields.GroupName,
+		database.ProjectFields.Description,
+		database.ProjectFields.AvatarURL,
+		database.ProjectFields.GitURL,
+		database.ProjectFields.BuildDefinition,
+	); err != nil {
+		return fmt.Errorf("migrating columns to not null for project: %w", err)
+	}
+
+	if err := migrateColumnsToNotNull(driver, db, &database.BuildParam{},
+		database.BuildParamFields.Value,
+	); err != nil {
+		return fmt.Errorf("migrating columns to not null for build_param: %w", err)
+	}
+
+	if err := migrateColumnsToNotNull(driver, db, &database.Param{},
+		database.ParamFields.Value,
+		database.ParamFields.DefaultValue,
+	); err != nil {
+		return fmt.Errorf("migrating columns to not null for param: %w", err)
+	}
+
+	if err := migrateColumnsToNotNull(driver, db, &database.Artifact{},
+		database.ArtifactFields.FileName,
+	); err != nil {
+		return fmt.Errorf("migrating columns to not null for param: %w", err)
+	}
+
+	if err := migrateColumnsToNotNull(driver, db, &database.TestResultSummary{},
+		database.TestResultSummaryFields.FileName,
+	); err != nil {
+		return fmt.Errorf("migrating columns to not null for test_result_summary: %w", err)
+	}
+
+	return nil
+}
+
+func migrateColumnsToNotNull(driver DBDriver, db *gorm.DB, model interface{}, fieldNames ...string) error {
+	if !db.Migrator().HasTable(model) {
+		log.Debug().WithStringf("model", "%T", model).Message("Skipping changing column to not null as the table does not exist.")
+		return nil
+	}
+	actualTypes, err := db.Migrator().ColumnTypes(model)
+	if err != nil {
+		return err
+	}
+	actualTypesPerDBName := map[string]gorm.ColumnType{}
+	for _, columnType := range actualTypes {
+		actualTypesPerDBName[columnType.Name()] = columnType
+	}
+
+	stmt := db.Model(model).Statement
+	if err := stmt.Parse(model); err != nil {
+		return err
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		for _, fieldName := range fieldNames {
+			wantedField := stmt.Schema.LookUpField(fieldName)
+			if wantedField == nil {
+				return fmt.Errorf("unknown field when changing to not null: %q", fieldName)
+			}
+			actualType, ok := actualTypesPerDBName[wantedField.DBName]
+			if !ok {
+				log.Warn().
+					WithStringf("model", "%T", model).
+					WithString("field", fieldName).
+					Message("Cannot change column to not null as the column does not exist in the table.")
+				continue
+			}
+			if err := migrateColumnToNotNull(driver, tx, model, wantedField, actualType); err != nil {
+				return err
+			}
+			log.Info().
+				WithStringf("model", "%T", model).
+				WithString("field", fieldName).
+				Message("Changed column to not null.")
+		}
+		return nil
+	})
+}
+
+func migrateColumnToNotNull(driver DBDriver, db *gorm.DB, model interface{}, want *schema.Field, actual gorm.ColumnType) error {
+	if want.PrimaryKey {
+		return fmt.Errorf("cannot operate changing the column to not null for a primary key: %q", want.Name)
+	}
+	if !want.NotNull {
+		return fmt.Errorf("struct field is not declared to be not null: %q", want.Name)
+	}
+	if nullable, ok := actual.Nullable(); !ok || !nullable {
+		// Already not null
+		return nil
+	}
+
+	defaultValue, err := sqlDefaultValue(want.DataType)
+	if err != nil {
+		return fmt.Errorf("get default value: %w", err)
+	}
+
+	defaultValueSQLString, err := sqlDefaultValueSQLString(want.DataType)
+	if err != nil {
+		return fmt.Errorf("get default value as SQL string: %w", err)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(model).Where(want.DBName, nil).Update(want.DBName, defaultValue).Error; err != nil {
+			return fmt.Errorf("set all to zero where %q is null: %w", want.DBName, err)
+		}
+
+		switch driver {
+		case DBDriverPostgres:
+			tableName := want.Schema.Table
+			if err := tx.
+				Exec(
+					fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "%s" SET DEFAULT %s`,
+						tableName, want.DBName, defaultValueSQLString),
+				).Error; err != nil {
+				return fmt.Errorf("set default to %q: %w", defaultValueSQLString, err)
+			}
+			if err := tx.
+				Exec(
+					fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "%s" SET NOT NULL`,
+						tableName, want.DBName),
+				).Error; err != nil {
+				return fmt.Errorf("set not null: %w", err)
+			}
+			return nil
+		case DBDriverSqlite:
+			// Sqlite migrator recreates the table with the field updated
+			return db.Migrator().AlterColumn(model, want.Name)
+		default:
+			return fmt.Errorf("migrating column to not null has not been implemented for this DB driver: %q", driver)
+		}
+	})
+}
+
+func sqlDefaultValue(dataType schema.DataType) (interface{}, error) {
+	switch dataType {
+	case schema.Bool:
+		return false, nil
+	case schema.Int:
+		return int(0), nil
+	case schema.Uint:
+		return uint(0), nil
+	case schema.Float:
+		return float32(0), nil
+	case schema.String:
+		return "", nil
+	default:
+		return nil, fmt.Errorf("unsupported data type: %q", dataType)
+	}
+}
+
+func sqlDefaultValueSQLString(dataType schema.DataType) (string, error) {
+	switch dataType {
+	case schema.Bool:
+		return "false", nil
+	case schema.Int, schema.Uint, schema.Float:
+		return "0", nil
+	case schema.String:
+		return "''", nil
+	default:
+		return "", fmt.Errorf("unsupported data type: %q", dataType)
+	}
 }

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -65,29 +65,37 @@ var TokenFields = struct {
 // Token holds credentials for a remote provider.
 type Token struct {
 	TokenID  uint   `gorm:"primaryKey"`
-	Token    string `gorm:"size:500; not null"`
-	UserName string `gorm:"size:500"`
+	Token    string `gorm:"size:500;not null"`
+	UserName string `gorm:"size:500;not null;default:''"`
 }
 
 // ProjectFields holds the Go struct field names for each field.
 // Useful in GORM .Where() statements to only select certain fields or in GORM
 // Preload statements to select the correct field to preload.
 var ProjectFields = struct {
-	ProjectID string
-	Name      string
-	GroupName string
-	TokenID   string
-	Token     string
-	Provider  string
-	Branches  string
+	ProjectID       string
+	Name            string
+	GroupName       string
+	Description     string
+	AvatarURL       string
+	TokenID         string
+	Token           string
+	Provider        string
+	BuildDefinition string
+	Branches        string
+	GitURL          string
 }{
-	ProjectID: "ProjectID",
-	Name:      "Name",
-	GroupName: "GroupName",
-	TokenID:   "TokenID",
-	Token:     "Token",
-	Provider:  "Provider",
-	Branches:  "Branches",
+	ProjectID:       "ProjectID",
+	Name:            "Name",
+	GroupName:       "GroupName",
+	Description:     "Description",
+	AvatarURL:       "AvatarURL",
+	TokenID:         "TokenID",
+	Token:           "Token",
+	Provider:        "Provider",
+	BuildDefinition: "BuildDefinition",
+	Branches:        "Branches",
+	GitURL:          "GitURL",
 }
 
 // ProjectColumns holds the DB column names for each field.
@@ -112,9 +120,9 @@ type Project struct {
 	Token           *Token    `gorm:"foreignKey:TokenID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT"`
 	ProviderID      uint      `gorm:"nullable;default:NULL;index:project_idx_provider_id"`
 	Provider        *Provider `gorm:"foreignKey:ProviderID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT"`
-	BuildDefinition string
-	Branches        []Branch `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
-	GitURL          string   `gorm:"not null;default:''"`
+	BuildDefinition string    `gorm:"not null;default:''"`
+	Branches        []Branch  `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	GitURL          string    `gorm:"not null;default:''"`
 }
 
 // BranchFields holds the Go struct field names for each field.
@@ -199,9 +207,9 @@ type Build struct {
 	ScheduledOn         null.Time           `gorm:"nullable;default:NULL"`
 	StartedOn           null.Time           `gorm:"nullable;default:NULL"`
 	CompletedOn         null.Time           `gorm:"nullable;default:NULL"`
-	GitBranch           string              `gorm:"size:300;default:'';not null"`
+	GitBranch           string              `gorm:"size:300;not null;default:''"`
 	Environment         null.String         `gorm:"nullable;size:40" swaggertype:"string"`
-	Stage               string              `gorm:"size:40;default:'';not null"`
+	Stage               string              `gorm:"size:40;not null;default:''"`
 	Params              []BuildParam        `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	IsInvalid           bool                `gorm:"not null;default:false"`
 	TestResultSummaries []TestResultSummary `gorm:"foreignKey:BuildID"`
@@ -232,13 +240,22 @@ func (buildStatus BuildStatus) IsValid() bool {
 	return buildStatus >= BuildScheduling && buildStatus <= BuildFailed
 }
 
+// BuildParamFields holds the Go struct field names for each field.
+// Useful in GORM .Where() statements to only select certain fields or in GORM
+// Preload statements to select the correct field to preload.
+var BuildParamFields = struct {
+	Value string
+}{
+	Value: "Value",
+}
+
 // BuildParam holds the name and value of an input parameter fed into a build.
 type BuildParam struct {
 	BuildParamID uint   `gorm:"primaryKey"`
 	BuildID      uint   `gorm:"not null;index:buildparam_idx_build_id"`
 	Build        *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	Name         string `gorm:"not null"`
-	Value        string `gorm:"nullable"`
+	Value        string `gorm:"not null;default:''"`
 }
 
 // Log is a single logged line for a build.
@@ -250,13 +267,24 @@ type Log struct {
 	Timestamp time.Time `gorm:"not null"`
 }
 
+// ParamFields holds the Go struct field names for each field.
+// Useful in GORM .Where() statements to only select certain fields or in GORM
+// Preload statements to select the correct field to preload.
+var ParamFields = struct {
+	Value        string
+	DefaultValue string
+}{
+	Value:        "Value",
+	DefaultValue: "DefaultValue",
+}
+
 // Param holds the definition of an input parameter for a project.
 type Param struct {
 	ParamID      int    `gorm:"primaryKey"`
 	Name         string `gorm:"not null"`
 	Type         string `gorm:"not null"`
-	Value        string
-	DefaultValue string
+	Value        string `gorm:"not null;default:''"`
+	DefaultValue string `gorm:"not null;default:''"`
 }
 
 // ArtifactColumns holds the DB column names for each field.
@@ -270,6 +298,15 @@ var ArtifactColumns = struct {
 	FileName:   "file_name",
 }
 
+// ArtifactFields holds the Go struct field names for each field.
+// Useful in GORM .Where() statements to only select certain fields or in GORM
+// Preload statements to select the correct field to preload.
+var ArtifactFields = struct {
+	FileName string
+}{
+	FileName: "FileName",
+}
+
 // Artifact holds the binary data as well as metadata about that binary such as
 // the file name and which build it belongs to.
 type Artifact struct {
@@ -277,14 +314,23 @@ type Artifact struct {
 	BuildID    uint   `gorm:"not null;index:artifact_idx_build_id"`
 	Build      *Build `gorm:"foreignKey:BuildID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	Name       string `gorm:"not null"`
-	FileName   string `gorm:"nullable"`
+	FileName   string `gorm:"not null;default:''"`
 	Data       []byte `gorm:"nullable"`
+}
+
+// TestResultSummaryFields holds the Go struct field names for each field.
+// Useful in GORM .Where() statements to only select certain fields or in GORM
+// Preload statements to select the correct field to preload.
+var TestResultSummaryFields = struct {
+	FileName string
+}{
+	FileName: "FileName",
 }
 
 // TestResultSummary contains data about a single test result file.
 type TestResultSummary struct {
 	TestResultSummaryID uint      `gorm:"primaryKey"`
-	FileName            string    `gorm:"nullable"`
+	FileName            string    `gorm:"not null;default:''"`
 	ArtifactID          uint      `gorm:"not null;index:testresultsummary_idx_artifact_id"`
 	Artifact            *Artifact `gorm:"foreignKey:ArtifactID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL"`
 	BuildID             uint      `gorm:"not null;index:testresultsummary_idx_build_id"`

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -105,16 +105,16 @@ var ProjectColumns = struct {
 type Project struct {
 	ProjectID       uint      `gorm:"primaryKey"`
 	Name            string    `gorm:"size:500;not null"`
-	GroupName       string    `gorm:"size:500"`
-	Description     string    `gorm:"size:500"`
-	AvatarURL       string    `gorm:"size:500"`
+	GroupName       string    `gorm:"size:500;not null;default:''"`
+	Description     string    `gorm:"size:500;not null;default:''"`
+	AvatarURL       string    `gorm:"size:500;not null;default:''"`
 	TokenID         uint      `gorm:"nullable;default:NULL;index:project_idx_token_id"`
 	Token           *Token    `gorm:"foreignKey:TokenID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT"`
 	ProviderID      uint      `gorm:"nullable;default:NULL;index:project_idx_provider_id"`
 	Provider        *Provider `gorm:"foreignKey:ProviderID;constraint:OnUpdate:RESTRICT,OnDelete:RESTRICT"`
-	BuildDefinition string    `sql:"type:text"`
-	Branches        []Branch  `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
-	GitURL          string    `gorm:"nullable;default:NULL"`
+	BuildDefinition string
+	Branches        []Branch `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	GitURL          string   `gorm:"not null;default:''"`
 }
 
 // BranchFields holds the Go struct field names for each field.


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added custom migration code for migrating columns in PostgreSQL to add `NOT NULL`
- Changed all database fields that were non-pointers from `gorm:"nullable"` to `gorm:"not null;default:''"`

## Motivation

This adds consistency between the wharf-api and the database.

Some fields cannot be null, according to our database models, as we're using `string` and not `*string`. Because of this, GORM will never set the values to `NULL` in the database as it's solely relying on the value in Go. In other words: for all the changed fields in the database models, none *should* actually have the value `NULL` in the database, but instead only empty strings.

So the migration steps might be overkill, but I'd rather have them than not, just to catch those edge cases where someone might have updated a field via raw SQL manually, or if some previous migration added nullable columns.

The Postgres GORM migrator implementation could only change a column to nullable, but not from nullable to `NOT NULL`, probably because that's an errornous operation and requires default values. This new implementation does supply those default values.
