### PR TITLE
Allow cred/authorization header CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - Use `PUT /token/{tokenId}` instead of `PUT /token`
   - Use `PUT /project/{projectId}/branch` instead of `PUT /branches`
 
-
 - Deprecated POST search endpoints that took the search queries from the HTTP
   request body. They are still supported, but may be removed in the next major
   release (v6.0.0). Please refer to the new endpoints that use query parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v5.0.0 (WIP)
 
+- Enables setting specific origins for CORS via the
+  WHARF_HTTP_CORS_ALLOWORIGINS environment variable. This is to make sending
+  `Authorization` headers possible. (#101)
+
 - BREAKING: Removed all deprecated environment variable configs, which were
   marked as deprecated in v4.2.0/#38. Now all environment variables require the
   `WHARF_` prefix. (#87)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v5.0.0 (WIP)
 
-- Enables setting specific origins for CORS via the
-  WHARF_HTTP_CORS_ALLOWORIGINS environment variable. This is to make sending
-  `Authorization` headers possible. (#101)
-
 - BREAKING: Removed all deprecated environment variable configs, which were
   marked as deprecated in v4.2.0/#38. Now all environment variables require the
   `WHARF_` prefix. (#87)
@@ -45,12 +41,17 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - Use `PUT /token/{tokenId}` instead of `PUT /token`
   - Use `PUT /project/{projectId}/branch` instead of `PUT /branches`
 
+
 - Deprecated POST search endpoints that took the search queries from the HTTP
   request body. They are still supported, but may be removed in the next major
   release (v6.0.0). Please refer to the new endpoints that use query parameter
   instead. (#99)
 
   - Use `GET /project` instead of `GET /projects` or `POST /projects/search`
+
+- Enables setting specific origins for CORS via the
+  WHARF_HTTP_CORS_ALLOWORIGINS environment variable. This is to make sending
+  `Authorization` headers possible. (#101)
 
 - Added support for Sqlite. Default database driver is still Postgres.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
   - Use `GET /project` instead of `GET /projects` or `POST /projects/search`
 
-- Enables setting specific origins for CORS via the
-  WHARF_HTTP_CORS_ALLOWORIGINS environment variable. This is to make sending
-  `Authorization` headers possible. (#101)
+- Added configuration of specific origins for CORS via the environment variable
+  `WHARF_HTTP_CORS_ALLOWORIGINS` or the YAML key `http.cors.allowOrigins`. This
+  is to make sending `Authorization` headers possible. (#101)
 
 - Added support for Sqlite. Default database driver is still Postgres.
 

--- a/config.go
+++ b/config.go
@@ -127,7 +127,7 @@ type CORSConfig struct {
 	// results in the HTTP header "Access-Control-Allow-Origin".
 	//
 	// Added in v5.0.0.
-	AllowOrigins string
+	AllowOrigins []string
 }
 
 // CertConfig holds settings for certificates verification used when talking

--- a/config.go
+++ b/config.go
@@ -121,6 +121,13 @@ type CORSConfig struct {
 	//
 	// Added in v4.2.0.
 	AllowAllOrigins bool
+
+	// AllowOrigins enables CORS and allows the list of origins in the
+	// HTTP request origins when set. Practically speaking, this
+	// results in the HTTP header "AllowOrigins".
+	//
+	// Added in v5.0.0.
+	AllowOrigins string
 }
 
 // CertConfig holds settings for certificates verification used when talking

--- a/config.go
+++ b/config.go
@@ -124,7 +124,7 @@ type CORSConfig struct {
 
 	// AllowOrigins enables CORS and allows the list of origins in the
 	// HTTP request origins when set. Practically speaking, this
-	// results in the HTTP header "AllowOrigins".
+	// results in the HTTP header "Access-Control-Allow-Origin".
 	//
 	// Added in v5.0.0.
 	AllowOrigins string

--- a/main.go
+++ b/main.go
@@ -90,7 +90,14 @@ func main() {
 		ginutil.RecoverProblem,
 	)
 
-	if config.HTTP.CORS.AllowAllOrigins {
+	if len(config.HTTP.CORS.AllowOrigins) > 0 {
+		log.Info().Message("Allowing " + config.HTTP.CORS.AllowOrigins + " origins in CORS.")
+		corsConfig := cors.DefaultConfig()
+		corsConfig.AllowOrigins = []string{config.HTTP.CORS.AllowOrigins}
+		corsConfig.AddAllowHeaders("Authorization")
+		corsConfig.AllowCredentials = true
+		r.Use(cors.New(corsConfig))
+	} else if config.HTTP.CORS.AllowAllOrigins {
 		log.Info().Message("Allowing all origins in CORS.")
 		corsConfig := cors.DefaultConfig()
 		corsConfig.AllowAllOrigins = true

--- a/main.go
+++ b/main.go
@@ -91,9 +91,11 @@ func main() {
 	)
 
 	if len(config.HTTP.CORS.AllowOrigins) > 0 {
-		log.Info().Message("Allowing " + config.HTTP.CORS.AllowOrigins + " origins in CORS.")
+		log.Info().
+			WithStringf("origin", "%v", config.HTTP.CORS.AllowOrigins).
+			Message("Allowing origins in CORS.")
 		corsConfig := cors.DefaultConfig()
-		corsConfig.AllowOrigins = []string{config.HTTP.CORS.AllowOrigins}
+		corsConfig.AllowOrigins = config.HTTP.CORS.AllowOrigins
 		corsConfig.AddAllowHeaders("Authorization")
 		corsConfig.AllowCredentials = true
 		r.Use(cors.New(corsConfig))


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

This adds a environment variable that allows setting a cors allowed origin. When this is set Authrization Bearer tokens will also be allowed to be sent. This overrides the allow all origins header. When sending credentials allow all origins is not allowed.

## Motivation

When sending credentials allow all origins is not allowed. The way the OICD login is set to work credentials need to be sent and will use the `authorization` header.
