### PR TITLE
Add OIDC access token validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   `WHARF_HTTP_CORS_ALLOWORIGINS` or the YAML key `http.cors.allowOrigins`. This
   is to make sending `Authorization` headers possible. (#101)
 
+- Added a slew of options for setting OIDC parameters (see WHARF_HTTP_OIDC_*)
+  for JWT token verification. Upon setting `WHARF_HTTP_OIDC_ENABLE=true` a
+  check will be enforced for requests sent to the api such that all
+  requests not carrying a valid bearer token will fail.
+
 - Added support for Sqlite. Default database driver is still Postgres.
 
   Note: wharf-api must be compiled with `CGO_ENABLED=1` (which is the default

--- a/config.go
+++ b/config.go
@@ -164,6 +164,8 @@ type OIDCConfig struct {
 	//
 	// Added in v5.0.0.
 	KeysURL string
+
+	UpdateInterval time.Duration
 }
 
 // CertConfig holds settings for certificates verification used when talking
@@ -310,6 +312,18 @@ type DBConfig struct {
 var DefaultConfig = Config{
 	HTTP: HTTPConfig{
 		BindAddress: "0.0.0.0:8080",
+		CORS: CORSConfig{
+			// :4200 is used when running wharf-web via `npm start` locally
+			// :5000 is used when running wharf-web via docker-compose locally
+			AllowOrigins: []string{"http://localhost:4200", "http://localhost:5000"},
+		},
+		OIDC: OIDCConfig{
+			Enable:         false,
+			IssuerURL:      "https://sts.windows.net/841df554-ef9d-48b1-bc6e-44cf8543a8fc/",
+			AudienceURL:    "api://wharf-internal",
+			KeysURL:        "https://login.microsoftonline.com/841df554-ef9d-48b1-bc6e-44cf8543a8fc/discovery/v2.0/keys",
+			UpdateInterval: time.Hour * 25,
+		},
 	},
 	DB: DBConfig{
 		Driver: DBDriverPostgres,

--- a/config.go
+++ b/config.go
@@ -116,7 +116,6 @@ type HTTPConfig struct {
 	//
 	// Added in v5.0.0.
 	OIDC OIDCConfig
-
 }
 
 // CORSConfig holds settings for the HTTP server's CORS settings.

--- a/config.go
+++ b/config.go
@@ -109,8 +109,7 @@ type HTTPConfig struct {
 	// Added in v4.2.0.
 	BasicAuth string
 
-	// OIDC
-	// SHOULD be use with HTTPS/SSL (unsecure without)
+	// OIDC SHOULD be use with HTTPS/SSL (unsecure without)
 	// Requires CORS set to specific origins.
 	// Return unauthorized on http requests unless valid OIDC access
 	// tokens sent through the Authorization header for all requests.

--- a/config.go
+++ b/config.go
@@ -109,10 +109,11 @@ type HTTPConfig struct {
 	// Added in v4.2.0.
 	BasicAuth string
 
-	// OIDC SHOULD be use with HTTPS/SSL (unsecure without)
+	// OIDC is only secure if using HTTPS/SSL.
 	// Requires CORS set to specific origins.
-	// Return unauthorized on http requests unless valid OIDC access
-	// tokens sent through the Authorization header for all requests.
+	//
+	// If enabled, HTTP requests without a valid OIDC access token in the Authorization
+	// header will be rejected with Unauthorized 401.
 	//
 	// Added in v5.0.0.
 	OIDC OIDCConfig

--- a/config.go
+++ b/config.go
@@ -115,7 +115,7 @@ type HTTPConfig struct {
 	// tokens sent through the Authorization header for all requests.
 	//
 	// Added in v5.0.0.
-	OIDC OICDConfig
+	OIDC OIDCConfig
 
 }
 
@@ -139,8 +139,8 @@ type CORSConfig struct {
 	AllowOrigins []string
 }
 
-// OICDConfig holds settings for the HTTP server's OIDC access token validation settings.
-type OICDConfig struct {
+// OIDCConfig holds settings for the HTTP server's OIDC access token validation settings.
+type OIDCConfig struct {
 
 	// Enable this functions as a switch to enable or disable the validation of OIDC
 	// access bearer tokens.

--- a/config.go
+++ b/config.go
@@ -142,19 +142,28 @@ type CORSConfig struct {
 // OICDConfig holds settings for the HTTP server's OIDC access token validation settings.
 type OICDConfig struct {
 
-	Enable bool
-
-	// OICDMetadataURL
-	//
-	// Sample URL https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
+	// Enable this functions as a switch to enable or disable the validation of OIDC
+	// access bearer tokens.
 	//
 	// Added in v5.0.0.
-	MetadataURL string
+	Enable bool
 
+	// IssuerURL an integral part of the access token. It should be checked such that
+	// only allowed OIDC targets can pass token validation.
+	//
+	// Added in v5.0.0.
 	IssuerURL string
 
+	// AudienceURL an integral part of the access token. It should be checked such that
+	// only the allowed application within a OIDC target can pass validation.
+	//
+	// Added in v5.0.0.
 	AudienceURL string
 
+	// KeysURL an integral part of the access token. It should be checked such that
+	// only OIDC targets with the expected keys pass validation.
+	//
+	// Added in v5.0.0.
 	KeysURL string
 }
 

--- a/config.go
+++ b/config.go
@@ -108,6 +108,16 @@ type HTTPConfig struct {
 	//
 	// Added in v4.2.0.
 	BasicAuth string
+
+	// OIDC
+	// SHOULD be use with HTTPS/SSL (unsecure without)
+	// Requires CORS set to specific origins.
+	// Return unauthorized on http requests unless valid OIDC access
+	// tokens sent through the Authorization header for all requests.
+	//
+	// Added in v5.0.0.
+	OIDC OICDConfig
+
 }
 
 // CORSConfig holds settings for the HTTP server's CORS settings.
@@ -128,6 +138,25 @@ type CORSConfig struct {
 	//
 	// Added in v5.0.0.
 	AllowOrigins []string
+}
+
+// OICDConfig holds settings for the HTTP server's OIDC access token validation settings.
+type OICDConfig struct {
+
+	Enable bool
+
+	// OICDMetadataURL
+	//
+	// Sample URL https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
+	//
+	// Added in v5.0.0.
+	MetadataURL string
+
+	IssuerURL string
+
+	AudienceURL string
+
+	KeysURL string
 }
 
 // CertConfig holds settings for certificates verification used when talking

--- a/config.go
+++ b/config.go
@@ -165,6 +165,11 @@ type OIDCConfig struct {
 	// Added in v5.0.0.
 	KeysURL string
 
+	// UpdateInterval defines the key rotation of the public RSA keys obtained
+	// by the OIDC keys URL. A value of 25 hours is both default and
+	// recommended.
+	//
+	// Added in v5.0.0.
 	UpdateInterval time.Duration
 }
 

--- a/config.go
+++ b/config.go
@@ -142,25 +142,25 @@ type CORSConfig struct {
 // OIDCConfig holds settings for the HTTP server's OIDC access token validation settings.
 type OIDCConfig struct {
 
-	// Enable this functions as a switch to enable or disable the validation of OIDC
+	// Enable functions as a switch to enable or disable the validation of OIDC
 	// access bearer tokens.
 	//
 	// Added in v5.0.0.
 	Enable bool
 
-	// IssuerURL an integral part of the access token. It should be checked such that
+	// IssuerURL is an integral part of the access token. It should be checked such that
 	// only allowed OIDC targets can pass token validation.
 	//
 	// Added in v5.0.0.
 	IssuerURL string
 
-	// AudienceURL an integral part of the access token. It should be checked such that
+	// AudienceURL is an integral part of the access token. It should be checked such that
 	// only the allowed application within a OIDC target can pass validation.
 	//
 	// Added in v5.0.0.
 	AudienceURL string
 
-	// KeysURL an integral part of the access token. It should be checked such that
+	// KeysURL is an integral part of the access token. It should be checked such that
 	// only OIDC targets with the expected keys pass validation.
 	//
 	// Added in v5.0.0.

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.7.4
-	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/go-playground/validator/v10 v10.9.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/iver-wharf/wharf-core v1.2.0
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.7.4
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/go-playground/validator/v10 v10.9.0 // indirect
 	github.com/iver-wharf/wharf-core v1.2.0
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,8 @@ github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFG
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFG
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.1.0 h1:XUgk2Ex5veyVFVeLm0xhusUTQybEbexJXrvPNOKkSY0=
+github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/main.go
+++ b/main.go
@@ -110,13 +110,14 @@ func main() {
 	healthModule{}.Register(r.Group("/api"))
 
 	if config.HTTP.OIDC.Enable {
-		rsaKeys, err := GetOIDCPublicKeys(config.HTTP.OIDC)
+		rsaKeys, err := GetOIDCPublicKeys(config.HTTP.OIDC.KeysURL)
 		if err != nil {
 			log.Error().WithError(err).Message("Failed to obtain OIDC public keys.")
 			os.Exit(1)
 		}
-		r.Use(VerifyTokenMiddleware(config.HTTP.OIDC, rsaKeys))
-		SubscribeToKeyURLUpdates(config.HTTP.OIDC, rsaKeys)
+		m := NewOIDCMiddleware(rsaKeys, config.HTTP.OIDC)
+		r.Use(m.VerifyTokenMiddleware)
+		m.SubscribeToKeyURLUpdates()
 	}
 
 	setupBasicAuth(r, config)

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func main() {
 	healthModule{}.Register(r.Group("/api"))
 
 	if config.HTTP.OIDC.Enable {
-		rsaKeys := GetOidcPublicKeys(config.HTTP.OIDC)
+		rsaKeys := GetOIDCPublicKeys(config.HTTP.OIDC)
 		r.Use(VerifyTokenMiddleware(config.HTTP.OIDC, rsaKeys))
 		SubscribeToKeyURLUpdates(config.HTTP.OIDC, rsaKeys)
 	}

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func main() {
 			log.Error().WithError(err).Message("Failed to obtain OIDC public keys.")
 			os.Exit(1)
 		}
-		m := NewOIDCMiddleware(rsaKeys, config.HTTP.OIDC)
+		m := newOIDCMiddleware(rsaKeys, config.HTTP.OIDC)
 		r.Use(m.VerifyTokenMiddleware)
 		m.SubscribeToKeyURLUpdates()
 	}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/rsa"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -111,11 +110,9 @@ func main() {
 	healthModule{}.Register(r.Group("/api"))
 
 	if config.HTTP.OIDC.Enable {
-		var rsaKeys = make(map[string]*rsa.PublicKey)
-		oidcService := oidcService{&rsaKeys}
-		oidcService.GetPublicKeys(config.HTTP.OIDC)
-		r.Use(oidcService.VerifyTokenMiddleware(config.HTTP.OIDC))
-		// TODO implement key rotation - oidcService.SubscribeToKeyURLUpdates()
+		rsakeys := GetOidcPublicKeys(config.HTTP.OIDC)
+		r.Use(VerifyTokenMiddleware(config.HTTP.OIDC,rsakeys))
+		SubscribeToKeyURLUpdates(config.HTTP.OIDC,rsakeys)
 	}
 
 	setupBasicAuth(r, config)

--- a/main.go
+++ b/main.go
@@ -110,9 +110,9 @@ func main() {
 	healthModule{}.Register(r.Group("/api"))
 
 	if config.HTTP.OIDC.Enable {
-		rsakeys := GetOidcPublicKeys(config.HTTP.OIDC)
-		r.Use(VerifyTokenMiddleware(config.HTTP.OIDC,rsakeys))
-		SubscribeToKeyURLUpdates(config.HTTP.OIDC,rsakeys)
+		rsaKeys := GetOidcPublicKeys(config.HTTP.OIDC)
+		r.Use(VerifyTokenMiddleware(config.HTTP.OIDC, rsaKeys))
+		SubscribeToKeyURLUpdates(config.HTTP.OIDC, rsaKeys)
 	}
 
 	setupBasicAuth(r, config)

--- a/main.go
+++ b/main.go
@@ -112,7 +112,8 @@ func main() {
 	if config.HTTP.OIDC.Enable {
 		rsaKeys, err := GetOIDCPublicKeys(config.HTTP.OIDC)
 		if err != nil {
-			panic(err)
+			log.Error().WithError(err).Message("Failed to obtain OIDC public keys.")
+			os.Exit(1)
 		}
 		r.Use(VerifyTokenMiddleware(config.HTTP.OIDC, rsaKeys))
 		SubscribeToKeyURLUpdates(config.HTTP.OIDC, rsaKeys)

--- a/main.go
+++ b/main.go
@@ -110,7 +110,10 @@ func main() {
 	healthModule{}.Register(r.Group("/api"))
 
 	if config.HTTP.OIDC.Enable {
-		rsaKeys := GetOIDCPublicKeys(config.HTTP.OIDC)
+		rsaKeys, err := GetOIDCPublicKeys(config.HTTP.OIDC)
+		if err != nil {
+			panic(err)
+		}
 		r.Use(VerifyTokenMiddleware(config.HTTP.OIDC, rsaKeys))
 		SubscribeToKeyURLUpdates(config.HTTP.OIDC, rsaKeys)
 	}

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -33,8 +33,8 @@ import (
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// GetOidcPublicKeys return the public keys of the currently set WHARF_HTTP_OIDC_KeysURL.
-func GetOidcPublicKeys(config OIDCConfig) *map[string]*rsa.PublicKey {
+// GetOIDCPublicKeys return the public keys of the currently set WHARF_HTTP_OIDC_KeysURL.
+func GetOIDCPublicKeys(config OIDCConfig) *map[string]*rsa.PublicKey {
 	rsaKeys := make(map[string]*rsa.PublicKey)
 	var body map[string]interface{}
 	resp, err := http.Get(config.KeysURL)
@@ -105,7 +105,7 @@ func SubscribeToKeyURLUpdates(config OIDCConfig, rsakeys *map[string]*rsa.Public
 	go func() {
 		for {
 			<-fetchOidcKeysTicker.C
-			rsakeys = GetOidcPublicKeys(config)
+			rsakeys = GetOIDCPublicKeys(config)
 		}
 	}()
 }

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt"
+)
+
+// Largely taken from https://developer.okta.com/blog/2021/01/04/offline-jwt-validation-with-go
+
+type oidcService struct {
+	rsakeys *map[string]*rsa.PublicKey
+}
+
+func (oidc oidcService) GetPublicKeys(config OICDConfig) {
+	var body map[string]interface{}
+	resp, err := http.Get(config.KeysURL)
+	if err != nil {
+		log.Error().WithError(err).Message("Could not fetch from KeysURL.")
+	}
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	if err != nil {
+		log.Error().WithError(err).Message("Failed to decode login JWT Keys.")
+	}
+	for _, bodykey := range body["keys"].([]interface{}) {
+		key := bodykey.(map[string]interface{})
+		kid := key["kid"].(string)
+		rsakey := new(rsa.PublicKey)
+		number, _ := base64.RawURLEncoding.DecodeString(key["n"].(string))
+		rsakey.N = new(big.Int).SetBytes(number)
+		rsakey.E = 65537
+		(*oidc.rsakeys)[kid] = rsakey
+	}
+}
+
+// As a standard OICD login provider keys should be checked for updates ever 1 day 1 hour.
+func (oidc oidcService) SubscribeToKeyURLUpdates() {
+	// TODO Implement
+	panic("If you see this then you should implement this logic.")
+}
+
+func (oidc oidcService) VerifyTokenMiddleware(config OICDConfig) gin.HandlerFunc {
+	return func (ginContext *gin.Context) {
+		// middleware
+		isValid := false
+		errorMessage := ""
+		tokenString := ginContext.Request.Header.Get("Authorization")
+		if strings.HasPrefix(tokenString, "Bearer ") {
+			tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+			token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+				return (*oidc.rsakeys)[token.Header["kid"].(string)], nil
+			})
+			if err != nil {
+				errorMessage = err.Error()
+			} else if !token.Valid {
+				errorMessage = "Invalid token"
+			} else if token.Header["alg"] == nil {
+				errorMessage = "alg must be defined"
+			} else if token.Claims.(jwt.MapClaims)["aud"] != config.AudienceURL {
+				errorMessage = "Invalid aud"
+			} else if !strings.Contains(token.Claims.(jwt.MapClaims)["iss"].(string), config.IssuerURL) {
+				errorMessage = "Invalid iss"
+			} else {
+				isValid = true
+			}
+			if !isValid {
+				ginContext.String(http.StatusForbidden, errorMessage)
+				ginContext.AbortWithStatus(http.StatusUnauthorized)
+			}
+		} else {
+			ginContext.AbortWithStatus(http.StatusUnauthorized)
+		}
+	}
+}

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -15,6 +15,7 @@ import (
 
 // Largely taken from https://developer.okta.com/blog/2021/01/04/offline-jwt-validation-with-go
 
+// GetOidcPublicKeys return the public keys of the currently set WHARF_HTTP_OIDC_KeysURL.
 func GetOidcPublicKeys(config OIDCConfig) *map[string]*rsa.PublicKey {
 	rsaKeys := make(map[string]*rsa.PublicKey)
 	var body map[string]interface{}
@@ -40,6 +41,9 @@ func GetOidcPublicKeys(config OIDCConfig) *map[string]*rsa.PublicKey {
 	return &rsaKeys
 }
 
+// VerifyTokenMiddleware is a gin middleware function that enforces validity of the access bearer token on every
+// request. This uses the environment vars WHARF_HTTP_OIDC_IssuerURL and WHARF_HTTP_OIDC_AudienceURL as limiters
+// that control the variety of tokens that pass validation.
 func VerifyTokenMiddleware(config OIDCConfig, rsaKeys *map[string]*rsa.PublicKey) gin.HandlerFunc {
 	return func (ginContext *gin.Context) {
 		if *rsaKeys == nil {
@@ -76,6 +80,7 @@ func VerifyTokenMiddleware(config OIDCConfig, rsaKeys *map[string]*rsa.PublicKey
 	}
 }
 
+// SubscribeToKeyURLUpdates ensures new keys are fetched as necessary.
 // As a standard OIDC login provider keys should be checked for updates ever 1 day 1 hour.
 func SubscribeToKeyURLUpdates(config OIDCConfig, rsakeys *map[string]*rsa.PublicKey) {
 	fetchOidcKeysTicker := time.NewTicker(time.Hour * 25)

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -12,9 +12,10 @@ import (
 
 	"github.com/golang-jwt/jwt"
 )
+
 // Largely taken from https://developer.okta.com/blog/2021/01/04/offline-jwt-validation-with-go
 
-func GetOidcPublicKeys(config OICDConfig) *map[string]*rsa.PublicKey {
+func GetOidcPublicKeys(config OIDCConfig) *map[string]*rsa.PublicKey {
 	rsaKeys := make(map[string]*rsa.PublicKey)
 	var body map[string]interface{}
 	resp, err := http.Get(config.KeysURL)
@@ -39,7 +40,7 @@ func GetOidcPublicKeys(config OICDConfig) *map[string]*rsa.PublicKey {
 	return &rsaKeys
 }
 
-func VerifyTokenMiddleware(config OICDConfig, rsaKeys *map[string]*rsa.PublicKey) gin.HandlerFunc {
+func VerifyTokenMiddleware(config OIDCConfig, rsaKeys *map[string]*rsa.PublicKey) gin.HandlerFunc {
 	return func (ginContext *gin.Context) {
 		if *rsaKeys == nil {
 			log.Warn().Message("RsaKeys for OIDC have not been set (http:500).")
@@ -75,8 +76,8 @@ func VerifyTokenMiddleware(config OICDConfig, rsaKeys *map[string]*rsa.PublicKey
 	}
 }
 
-// As a standard OICD login provider keys should be checked for updates ever 1 day 1 hour.
-func SubscribeToKeyURLUpdates(config OICDConfig, rsakeys *map[string]*rsa.PublicKey) {
+// As a standard OIDC login provider keys should be checked for updates ever 1 day 1 hour.
+func SubscribeToKeyURLUpdates(config OIDCConfig, rsakeys *map[string]*rsa.PublicKey) {
 	fetchOidcKeysTicker := time.NewTicker(time.Hour * 25)
 	go func() {
 		for {

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -43,7 +43,6 @@ func GetOIDCPublicKeys(keysURL string) (map[string]*rsa.PublicKey, error) {
 	resp, err := http.Get(keysURL)
 	if err != nil {
 		return nil, fmt.Errorf("http GET keys URL: %w", err)
-		//log.Error().WithError(err).Message("Could not fetch from KeysURL.")
 	}
 	var body struct {
 		Keys []struct {
@@ -54,7 +53,6 @@ func GetOIDCPublicKeys(keysURL string) (map[string]*rsa.PublicKey, error) {
 	err = json.NewDecoder(resp.Body).Decode(&body)
 	if err != nil {
 		return nil, fmt.Errorf("decode keys payload: %w", err)
-		//log.Error().WithError(err).Message("Failed to decode login JWT Keys.")
 	}
 	log.Debug().Message("Updating keys for oidc.")
 	rsaExponent := 65537

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -37,7 +37,7 @@ import (
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// GetOIDCPublicKeys return the public keys of the currently set WHARF_HTTP_OIDC_KeysURL.
+// GetOIDCPublicKeys returns the public keys of the currently set WHARF_HTTP_OIDC_KEYSURL.
 func GetOIDCPublicKeys(keysURL string) (map[string]*rsa.PublicKey, error) {
 	rsaKeys := make(map[string]*rsa.PublicKey)
 	resp, err := http.Get(keysURL)

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // Largely taken from https://developer.okta.com/blog/2021/01/04/offline-jwt-validation-with-go

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -85,7 +85,7 @@ type oidcMiddleware struct {
 }
 
 // VerifyTokenMiddleware is a gin middleware function that enforces validity of the access bearer token on every
-// request. This uses the environment vars WHARF_HTTP_OIDC_IssuerURL and WHARF_HTTP_OIDC_AudienceURL as limiters
+// request. This uses the environment vars WHARF_HTTP_OIDC_ISSUERURL and WHARF_HTTP_OIDC_AUDIENCEURL as limiters
 // that control the variety of tokens that pass validation.
 func (m *oidcMiddleware) VerifyTokenMiddleware(ginContext *gin.Context) {
 	if m.rsaKeys == nil {

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -14,7 +14,24 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-// Largely taken from https://developer.okta.com/blog/2021/01/04/offline-jwt-validation-with-go
+// This is a modified version of the code provided in the follow blog post and
+// GitHub repository:
+// - https://developer.okta.com/blog/2021/01/04/offline-jwt-validation-with-go
+// - https://github.com/oktadev/okta-offline-jwt-validation-example/tree/a61cc73bf893686c1efe67ce86448047205826bc
+//
+// Copyright 2019 Okta, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // GetOidcPublicKeys return the public keys of the currently set WHARF_HTTP_OIDC_KeysURL.
 func GetOidcPublicKeys(config OIDCConfig) *map[string]*rsa.PublicKey {

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -57,13 +57,13 @@ func VerifyTokenMiddleware(config OICDConfig, rsaKeys *map[string]*rsa.PublicKey
 		if err != nil {
 			errorMessage = err.Error()
 		} else if !token.Valid {
-			errorMessage = "Invalid token"
+			errorMessage = "Invalid access bearer token."
 		} else if token.Header["alg"] == nil {
-			errorMessage = "alg must be defined"
+			errorMessage = "Missing 'alg' field in authorization JWT header."
 		} else if token.Claims.(jwt.MapClaims)["aud"] != config.AudienceURL {
-			errorMessage = "Invalid aud"
+			errorMessage = "Invalid 'aud' field in authorization JWT header."
 		} else if !strings.Contains(token.Claims.(jwt.MapClaims)["iss"].(string), config.IssuerURL) {
-			errorMessage = "Invalid iss"
+			errorMessage = "Invalid 'iss' field in authorization JWT header."
 		} else {
 			isValid = true
 		}

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -4,11 +4,12 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/gin-gonic/gin"
 	"math/big"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/gin-gonic/gin"
 
 	"github.com/golang-jwt/jwt/v4"
 )
@@ -45,7 +46,7 @@ func GetOidcPublicKeys(config OIDCConfig) *map[string]*rsa.PublicKey {
 // request. This uses the environment vars WHARF_HTTP_OIDC_IssuerURL and WHARF_HTTP_OIDC_AudienceURL as limiters
 // that control the variety of tokens that pass validation.
 func VerifyTokenMiddleware(config OIDCConfig, rsaKeys *map[string]*rsa.PublicKey) gin.HandlerFunc {
-	return func (ginContext *gin.Context) {
+	return func(ginContext *gin.Context) {
 		if *rsaKeys == nil {
 			log.Warn().Message("RsaKeys for OIDC have not been set (http:500).")
 			ginContext.AbortWithStatus(http.StatusInternalServerError)

--- a/oidc_middleware.go
+++ b/oidc_middleware.go
@@ -26,13 +26,14 @@ func GetOidcPublicKeys(config OICDConfig) *map[string]*rsa.PublicKey {
 		log.Error().WithError(err).Message("Failed to decode login JWT Keys.")
 	}
 	log.Debug().Message("Updating keys for oidc.")
+	rsaExponent := 65537
 	for _, bodykey := range body["keys"].([]interface{}) {
 		key := bodykey.(map[string]interface{})
 		kid := key["kid"].(string)
 		rsakey := new(rsa.PublicKey)
 		number, _ := base64.RawURLEncoding.DecodeString(key["n"].(string))
 		rsakey.N = new(big.Int).SetBytes(number)
-		rsakey.E = 65537
+		rsakey.E = rsaExponent
 		rsaKeys[kid] = rsakey
 	}
 	return &rsaKeys

--- a/utils_test.go
+++ b/utils_test.go
@@ -93,21 +93,3 @@ func TestNewLikeContainsValue(t *testing.T) {
 		})
 	}
 }
-
-func TestPointers(t *testing.T) {
-	myMap := map[string]int{
-		"foo": 123,
-	}
-
-	myMapPtr := &myMap
-
-	var f = func(localMapPtr *map[string]int) {
-		myNewMap := map[string]int{
-			"bar": 456,
-		}
-		localMapPtr = &myNewMap
-	}
-
-	f(myMapPtr)
-	assert.Equal(t, 456, (*myMapPtr)["bar"])
-}

--- a/utils_test.go
+++ b/utils_test.go
@@ -93,3 +93,21 @@ func TestNewLikeContainsValue(t *testing.T) {
 		})
 	}
 }
+
+func TestPointers(t *testing.T) {
+	myMap := map[string]int{
+		"foo": 123,
+	}
+
+	myMapPtr := &myMap
+
+	var f = func(localMapPtr *map[string]int) {
+		myNewMap := map[string]int{
+			"bar": 456,
+		}
+		localMapPtr = &myNewMap
+	}
+
+	f(myMapPtr)
+	assert.Equal(t, 456, (*myMapPtr)["bar"])
+}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

Requires merge of 
 - [x] https://github.com/iver-wharf/wharf-api/pull/101


## Summary

Added a slew of options for setting OIDC parameters for JWT token verification. Upon setting enable this will check will be enforced for requests sent to the api such that all requests not carrying a valid bearer token will fail.

## Motivation

This works in coalition with the coresponding frontend implementation https://github.com/iver-wharf/wharf-web/pull/70. Both PRs make up all the needed code to get basics for OIDC working.
