### PR TITLE
Added database.SafeSQLName type

### DIFF
--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -27,6 +27,13 @@ import (
 // One seems to take precedence, but to make sure and to keep the code
 // consistent we add it to both referencing fields.
 
+// SafeSQLName represents a value that is safe to use as an SQL table or column
+// name without the need of escaping.
+//
+// It is merely semantical and has no validation attached. Values of this type
+// should never be constructed from user input.
+type SafeSQLName string
+
 // ProviderFields holds the Go struct field names for each field.
 // Useful in GORM .Where() statements to only select certain fields or in GORM
 // Preload statements to select the correct field to preload.
@@ -104,12 +111,12 @@ var ProjectFields = struct {
 // Useful in GORM .Order() statements to order the results based on a specific
 // column, which does not support the regular Go field names.
 var ProjectColumns = struct {
-	ProjectID   string
-	Name        string
-	GroupName   string
-	Description string
-	TokenID     string
-	GitURL      string
+	ProjectID   SafeSQLName
+	Name        SafeSQLName
+	GroupName   SafeSQLName
+	Description SafeSQLName
+	TokenID     SafeSQLName
+	GitURL      SafeSQLName
 }{
 	ProjectID:   "project_id",
 	Name:        "name",
@@ -156,8 +163,8 @@ var BranchFields = struct {
 // Useful in GORM .Order() statements to order the results based on a specific
 // column, which does not support the regular Go field names.
 var BranchColumns = struct {
-	BranchID string
-	Name     string
+	BranchID SafeSQLName
+	Name     SafeSQLName
 }{
 	BranchID: "branch_id",
 	Name:     "name",
@@ -190,14 +197,14 @@ var BuildFields = struct {
 // Useful in GORM .Order() statements to order the results based on a specific
 // column, which does not support the regular Go field names.
 var BuildColumns = struct {
-	BuildID     string
-	StatusID    string
-	ScheduledOn string
-	StartedOn   string
-	CompletedOn string
-	Environment string
-	Stage       string
-	IsInvalid   string
+	BuildID     SafeSQLName
+	StatusID    SafeSQLName
+	ScheduledOn SafeSQLName
+	StartedOn   SafeSQLName
+	CompletedOn SafeSQLName
+	Environment SafeSQLName
+	Stage       SafeSQLName
+	IsInvalid   SafeSQLName
 }{
 	BuildID:     "build_id",
 	StatusID:    "status_id",
@@ -303,8 +310,8 @@ type Param struct {
 // Useful in GORM .Order() statements to order the results based on a specific
 // column, which does not support the regular Go field names.
 var ArtifactColumns = struct {
-	ArtifactID string
-	FileName   string
+	ArtifactID SafeSQLName
+	FileName   SafeSQLName
 }{
 	ArtifactID: "artifact_id",
 	FileName:   "file_name",

--- a/pkg/orderby/example_test.go
+++ b/pkg/orderby/example_test.go
@@ -3,6 +3,7 @@ package orderby_test
 import (
 	"fmt"
 
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/iver-wharf/wharf-api/pkg/orderby"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -48,7 +49,7 @@ func ExampleParseDirection() {
 }
 
 func ExampleParse() {
-	fieldToColumnNames := map[string]string{
+	fieldToColumnNames := map[string]database.SafeSQLName{
 		"buildId": "build_id",
 	}
 	fields := []string{
@@ -68,28 +69,6 @@ func ExampleParse() {
 	// Sort by "build_id asc"
 	// Sort by "build_id desc"
 	// Invalid sort order: failed mapping field name to column name: "foobar": invalid or unsupported ordering field
-	// Invalid sort order: failed parsing ordering direction: "foo": invalid direction, only 'asc' or 'desc' supported
-}
-
-func ExampleParse_withoutNameMapping() {
-	fields := []string{
-		"buildId asc",
-		"  buildId   desc  ",
-		"foobar asc",
-		"buildId foo",
-	}
-	for _, field := range fields {
-		// leave second argument as nil
-		if order, err := orderby.Parse(field, nil); err != nil {
-			fmt.Printf("Invalid sort order: %v\n", err)
-		} else {
-			fmt.Printf("Sort by %q\n", order)
-		}
-	}
-	// Output:
-	// Sort by "buildId asc"
-	// Sort by "buildId desc"
-	// Sort by "foobar asc"
 	// Invalid sort order: failed parsing ordering direction: "foo": invalid direction, only 'asc' or 'desc' supported
 }
 

--- a/pkg/orderby/orderby_test.go
+++ b/pkg/orderby/orderby_test.go
@@ -3,12 +3,18 @@ package orderby
 import (
 	"testing"
 
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func TestParse_errorOnNilMap(t *testing.T) {
+	unwanted, err := Parse("foo asc", nil)
+	assert.ErrorIs(t, err, ErrNilParseMap, "unexpected result:", unwanted)
+}
+
 func TestParse_ErrorPath(t *testing.T) {
-	fieldToColumnNames := map[string]string{
+	fieldToColumnNames := map[string]database.SafeSQLName{
 		"buildId": "build_id",
 	}
 	testCases := []struct {
@@ -61,13 +67,13 @@ func TestParse_ErrorPath(t *testing.T) {
 }
 
 func TestParse_HappyPath(t *testing.T) {
-	fieldToColumnNames := map[string]string{
+	fieldToColumnNames := map[string]database.SafeSQLName{
 		"buildId": "build_id",
 	}
 	testCases := []struct {
 		name     string
 		input    string
-		namesMap map[string]string
+		namesMap map[string]database.SafeSQLName
 		want     Column
 	}{
 		{
@@ -81,24 +87,6 @@ func TestParse_HappyPath(t *testing.T) {
 			input:    "buildId desc",
 			namesMap: fieldToColumnNames,
 			want:     Column{"build_id", Desc},
-		},
-		{
-			name:     "valid unmapped asc",
-			input:    "buildId asc",
-			namesMap: nil,
-			want:     Column{"buildId", Asc},
-		},
-		{
-			name:     "valid unmapped desc",
-			input:    "buildId desc",
-			namesMap: nil,
-			want:     Column{"buildId", Desc},
-		},
-		{
-			name:     "separated by tab",
-			input:    "buildId\tdesc",
-			namesMap: nil,
-			want:     Column{"buildId", Desc},
 		},
 		{
 			name:     "excess whitespace",

--- a/pkg/orderby/slice.go
+++ b/pkg/orderby/slice.go
@@ -3,6 +3,7 @@ package orderby
 import (
 	"strings"
 
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
 	"gorm.io/gorm/clause"
 )
 
@@ -48,7 +49,7 @@ func (slice Slice) ClauseIfNone(ifNone Column) clause.Expression {
 
 // ParseSlice returns a new slice where each element has been interpreted by the
 // Parse function, or the error of the first failed parsing.
-func ParseSlice(queries []string, fieldToColumnNames map[string]string) (Slice, error) {
+func ParseSlice(queries []string, fieldToColumnNames map[string]database.SafeSQLName) (Slice, error) {
 	sqlOrderings := make([]Column, len(queries))
 	for i, qo := range queries {
 		orderBy, err := Parse(qo, fieldToColumnNames)

--- a/project.go
+++ b/project.go
@@ -49,7 +49,7 @@ func (m projectModule) Register(g *gin.RouterGroup) {
 	}
 }
 
-var projectJSONToColumns = map[string]string{
+var projectJSONToColumns = map[string]database.SafeSQLName{
 	response.ProjectJSONFields.ProjectID:   database.ProjectColumns.ProjectID,
 	response.ProjectJSONFields.Name:        database.ProjectColumns.Name,
 	response.ProjectJSONFields.GroupName:   database.ProjectColumns.GroupName,
@@ -129,7 +129,7 @@ func (m projectModule) getProjectListHandler(c *gin.Context) {
 		}, where.NonNilFieldNames()...).
 		Scopes(
 			optionalLimitOffsetScope(params.Limit, params.Offset),
-			whereLikeScope(map[string]*string{
+			whereLikeScope(map[database.SafeSQLName]*string{
 				database.ProjectColumns.Name:        params.NameMatch,
 				database.ProjectColumns.GroupName:   params.GroupNameMatch,
 				database.ProjectColumns.Description: params.DescriptionMatch,
@@ -153,7 +153,7 @@ func (m projectModule) getProjectListHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, resProjects)
 }
 
-var buildJSONToColumns = map[string]string{
+var buildJSONToColumns = map[string]database.SafeSQLName{
 	response.BuildJSONFields.BuildID:     database.BuildColumns.BuildID,
 	response.BuildJSONFields.Environment: database.BuildColumns.Environment,
 	response.BuildJSONFields.CompletedOn: database.BuildColumns.CompletedOn,


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added type `database.SafeSQLName`
- Changed in `project.go`, `util.go`, and `orderby.go` to use `database.SafeSQLName` instead
- Changed orderby.Parse to error on nil, where it before returned the field name instead which may or may not be an invalid SQL column name.

## Motivation

Having a designated type for the column names makes it harder to accidentally use a user input as the column name when creating SQL queries, such as in `util.go`.

This now creates a compilation error:

```go
var columnName database.SafeSQLName
sql := columnName + " LIKE ?"
```
