### PR TITLE
Added Codacy exclude_paths for deprecated package

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+engines:
+  duplication:
+    enabled: true
+    exclude_paths:
+      - internal/deprecated/**


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `.codacy.yml`

## Motivation

This disables the duplication check for the `internal/deprecated/...` files in this repo.

I've just moved deprecated endpoints into that dir, in the plan of removing them on the next major version bump. So refactoring them to not have duplicated code with the `project.go`, `providers.go`, etc files in the repo root directory seems extremely superfluous to me.

Based off docs: https://docs.codacy.com/repositories-configure/codacy-configuration-file/