### PR TITLE
Added RemoteProjectID to Project structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `test_result_summary.file_name`
   - `token.user_name`
 
+- Added new field `RemoteProjectID` to the project model. (#112)
+
 ## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -74,6 +74,7 @@ type Token struct {
 // Preload statements to select the correct field to preload.
 var ProjectFields = struct {
 	ProjectID       string
+	RemoteProjectID string
 	Name            string
 	GroupName       string
 	Description     string
@@ -104,19 +105,21 @@ var ProjectFields = struct {
 // Useful in GORM .Order() statements to order the results based on a specific
 // column, which does not support the regular Go field names.
 var ProjectColumns = struct {
-	ProjectID   string
-	Name        string
-	GroupName   string
-	Description string
-	TokenID     string
-	GitURL      string
+	ProjectID       string
+	RemoteProjectID string
+	Name            string
+	GroupName       string
+	Description     string
+	TokenID         string
+	GitURL          string
 }{
-	ProjectID:   "project_id",
-	Name:        "name",
-	GroupName:   "group_name",
-	Description: "description",
-	TokenID:     "token_id",
-	GitURL:      "git_url",
+	ProjectID:       "project_id",
+	RemoteProjectID: "remote_project_id",
+	Name:            "name",
+	GroupName:       "group_name",
+	Description:     "description",
+	TokenID:         "token_id",
+	GitURL:          "git_url",
 }
 
 // Project holds data about an imported project. A lot of the data is expected
@@ -124,6 +127,7 @@ var ProjectColumns = struct {
 // and avatar.
 type Project struct {
 	ProjectID       uint      `gorm:"primaryKey"`
+	RemoteProjectID string    `gorm:"not null;default:''"`
 	Name            string    `gorm:"size:500;not null"`
 	GroupName       string    `gorm:"size:500;not null;default:''"`
 	Description     string    `gorm:"size:500;not null;default:''"`
@@ -135,7 +139,6 @@ type Project struct {
 	BuildDefinition string    `gorm:"not null;default:''"`
 	Branches        []Branch  `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	GitURL          string    `gorm:"not null;default:''"`
-	RemoteProjectID string    `gorm:"not null;default:''"`
 }
 
 // BranchFields holds the Go struct field names for each field.

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -135,6 +135,7 @@ type Project struct {
 	BuildDefinition string    `gorm:"not null;default:''"`
 	Branches        []Branch  `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	GitURL          string    `gorm:"not null;default:''"`
+	RemoteProjectID string    `gorm:"not null;default:''"`
 }
 
 // BranchFields holds the Go struct field names for each field.

--- a/pkg/model/request/request.go
+++ b/pkg/model/request/request.go
@@ -94,6 +94,7 @@ type Project struct {
 	ProviderID      uint   `json:"providerId" minimum:"0"`
 	BuildDefinition string `json:"buildDefinition"`
 	GitURL          string `json:"gitUrl"`
+	RemoteProjectID string `json:"remoteProjectId"`
 }
 
 // ProjectUpdate specifies fields when updating a project.

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -142,22 +142,25 @@ type Ping struct {
 // Useful in ordering statements to map the correct field to the correct
 // database column.
 var ProjectJSONFields = struct {
-	ProjectID   string
-	Name        string
-	GroupName   string
-	Description string
-	GitURL      string
+	ProjectID       string
+	RemoteProjectID string
+	Name            string
+	GroupName       string
+	Description     string
+	GitURL          string
 }{
-	ProjectID:   "projectId",
-	Name:        "name",
-	GroupName:   "groupName",
-	Description: "description",
-	GitURL:      "gitUrl",
+	ProjectID:       "projectId",
+	RemoteProjectID: "remoteProjectId",
+	Name:            "name",
+	GroupName:       "groupName",
+	Description:     "description",
+	GitURL:          "gitUrl",
 }
 
 // Project holds details about a project.
 type Project struct {
 	ProjectID             uint        `json:"projectId" minimum:"0"`
+	RemoteProjectID       string      `json:"remoteProjectId"`
 	Name                  string      `json:"name"`
 	GroupName             string      `json:"groupName"`
 	Description           string      `json:"description"`
@@ -168,7 +171,6 @@ type Project struct {
 	BuildDefinition       string      `json:"buildDefinition"`
 	Branches              []Branch    `json:"branches"`
 	GitURL                string      `json:"gitUrl"`
-	RemoteProjectID       string      `json:"remoteProjectId"`
 	ParsedBuildDefinition interface{} `json:"build" swaggertype:"object" extensions:"x-nullable"`
 }
 

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -168,6 +168,7 @@ type Project struct {
 	BuildDefinition       string      `json:"buildDefinition"`
 	Branches              []Branch    `json:"branches"`
 	GitURL                string      `json:"gitUrl"`
+	RemoteProjectID       string      `json:"remoteProjectId"`
 	ParsedBuildDefinition interface{} `json:"build" swaggertype:"object" extensions:"x-nullable"`
 }
 

--- a/pkg/modelconv/projectconv.go
+++ b/pkg/modelconv/projectconv.go
@@ -44,6 +44,7 @@ func DBProjectToResponse(dbProject database.Project) response.Project {
 		BuildDefinition:       dbProject.BuildDefinition,
 		Branches:              DBBranchesToResponses(dbProject.Branches),
 		GitURL:                dbProject.GitURL,
+		RemoteProjectID:       dbProject.RemoteProjectID,
 		ParsedBuildDefinition: parsedBuildDef,
 	}
 }
@@ -59,6 +60,7 @@ func ReqProjectToDatabase(reqProject request.Project) database.Project {
 		ProviderID:      ptrconv.UintZeroNil(reqProject.ProviderID),
 		BuildDefinition: reqProject.BuildDefinition,
 		GitURL:          reqProject.GitURL,
+		RemoteProjectID: reqProject.RemoteProjectID,
 	}
 }
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Added `RemoteProjectID` to all `Project` models.
Updated `projectconv.go` functions to support `RemoteProjectID`.

## Motivation

Required change to be able to store the remote project ID from remote providers.

---

Closes #12.