### PR TITLE
Added missing PUT /branches endpoint registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Deprecated PUT endpoints that took the object ID from the HTTP request body.
   They are still supported, but may be removed in the next major release
   (v6.0.0). Please refer to the new endpoints that takes the ID from the URL
-  path. (#88, #91, #94, #97)
+  path. (#88, #91, #94, #97, #113)
 
   - Use `PUT /project/{projectId}` instead of `PUT /project`
   - Use `PUT /provider/{providerId}` instead of `PUT /provider`

--- a/internal/deprecated/branch.go
+++ b/internal/deprecated/branch.go
@@ -22,6 +22,8 @@ func (m BranchModule) Register(g *gin.RouterGroup) {
 	{
 		branch.GET("/:branchId", m.GetBranchHandler)
 	}
+
+	g.PUT("/branches", m.updateProjectBranchListHandler)
 }
 
 // GetBranchHandler godoc


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added missing `PUT /branches` registration in `internal/deprecated` package

## Motivation

Forgot to register the endpoint in #91
