### PR TITLE
Added temp fix for CVE-2021-42374 & CVE-20210-42375

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,13 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `test_result_summary.file_name`
   - `token.user_name`
 
+- Security fix by changing version of `busybox` and `ssl_client` from 1.33.1-r3
+  to at least v1.33.1-r6 in `alpine` Docker base image to resolve
+  [CVE-2021-42374](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42374)
+  and [CVE-2021-42375](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42375),
+  as that package has not yet been updated in the upstream `alpine` Docker
+  image. (#115)
+
 ## v4.2.0 (2021-09-10)
 
 - Added support for the TZ environment variable (setting timezones ex.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,10 @@ RUN deploy/update-version.sh version.yaml \
 		&& make test
 
 FROM alpine:3.14 AS final
-RUN apk add --no-cache ca-certificates tzdata
+RUN apk add --no-cache ca-certificates tzdata \
+    && apk add --no-cache --upgrade \
+        # CVE-2021-42374 & CVE 2021-42375: https://github.com/alpinelinux/docker-alpine/issues/213
+        busybox>=1.33.1-r5
 WORKDIR /app
 COPY --from=build /src/main ./
 ENTRYPOINT ["/app/main"]


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `apk add --upgrade` to Dockerfile to update `busybox` package

## Motivation

Reported here:

https://github.com/iver-wharf/wharf-api/security/code-scanning/46?query=ref%3Arefs%2Fheads%2Fmaster

Not yet fixed in upstream alpine Docker image, but a simple `apk add --upgrade` fixes this
