### PR TITLE
Updated .gitignore & .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,28 @@
-.git
-.gitignore
-
-.dockerignore
-Dockerfile
-
-.wharf-ci.yml
+# Swaggo generated files
 docs
-.idea
 
+# Editor files
+**/*.swp
+.idea
+.vscode
+
+# NPM
+node_modules
 package.json
 package-lock.json
-node_modules
+
+# Binaries
+*.db
+*.tar
+*.tar.gz
+**/*.exe
+wharf-api
+
+# Git
+.git
+
+# Configs
+.gitignore
+.dockerignore
+Dockerfile
+.wharf-ci.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,18 @@
+# Swaggo generated files
 /docs/
+
+# Editor files
 *.swp
-*.exe
-.idea
+.idea/
+.vscode/
+
+# NPM
 /node_modules/
 /package-lock.json
-*.db
 
+# Binaries
+*.db
+*.tar
+*.tar.gz
+*.exe
 /wharf-api
-/wharf-api.exe


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed .gitignore & .dockerignore to be more organized and ignore more types, such as `*.db`, `*.tar`, and `*.tar.gz` files

## Motivation

`*.db` files are created by Sqlite.
`*.tar` files are created here and there, but one use case I came across in #115 is when saving Docker images to disk to be analysed.
