### PR TITLE
Paginated response fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   `"totalCount"` field for the overall query.
 
   By default all these new endpoints use a default limit of 100, but this can
-  be disabled by specifying `?limit=0`. (#109)
+  be disabled by specifying `?limit=0`. (#109, #118)
 
 - Added configuration of specific origins for CORS via the environment variable
   `WHARF_HTTP_CORS_ALLOWORIGINS` or the YAML key `http.cors.allowOrigins`. This
@@ -95,7 +95,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - test_result_detail
   - test_result_summary
 
-- Added test-result specific endpoints: (#43)
+- Added test-result specific endpoints: (#43, #118)
 
   - `POST /build/{buildid}/test-result`
 
@@ -116,7 +116,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
   Use `GET /build/{buildid}/test-result/list-summary` instead. The response
   data is slightly different; it has additional properties, and does not have a
-  `status` property. (#43, #77)
+  `status` property. (#43, #77, #118)
 
 - Changed format of all endpoint's path parameters from all lowercase to
   camelCase: (#76)

--- a/artifact.go
+++ b/artifact.go
@@ -120,7 +120,7 @@ func (m artifactModule) getBuildArtifactListHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response.PaginatedArtifacts{
-		Artifacts:  modelconv.DBArtifactsToResponses(dbArtifacts),
+		List:       modelconv.DBArtifactsToResponses(dbArtifacts),
 		TotalCount: totalCount,
 	})
 }

--- a/build.go
+++ b/build.go
@@ -237,7 +237,7 @@ func (m buildModule) getBuildListHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response.PaginatedBuilds{
-		Builds:     modelconv.DBBuildsToResponses(dbBuilds),
+		List:       modelconv.DBBuildsToResponses(dbBuilds),
 		TotalCount: totalCount,
 	})
 }

--- a/internal/deprecated/project.go
+++ b/internal/deprecated/project.go
@@ -199,7 +199,7 @@ func (m ProjectModule) getProjectBuildListHandler(c *gin.Context) {
 	}
 
 	resPaginated := response.PaginatedBuilds{
-		Builds:     modelconv.DBBuildsToResponses(dbBuilds),
+		List:       modelconv.DBBuildsToResponses(dbBuilds),
 		TotalCount: count,
 	}
 	c.JSON(http.StatusOK, resPaginated)

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -143,48 +143,48 @@ type Log struct {
 // PaginatedArtifacts is a list of artifacts as well as the explicit total count
 // field.
 type PaginatedArtifacts struct {
-	Artifacts  []Artifact `json:"artifacts"`
+	List       []Artifact `json:"list"`
 	TotalCount int64      `json:"totalCount"`
 }
 
 // PaginatedBuilds is a list of builds as well as an explicit total count field.
 type PaginatedBuilds struct {
-	Builds     []Build `json:"builds"`
+	List       []Build `json:"list"`
 	TotalCount int64   `json:"totalCount"`
 }
 
 // PaginatedProjects is a list of projects as well as the explicit total count
 // field.
 type PaginatedProjects struct {
-	Projects   []Project `json:"projects"`
+	List       []Project `json:"list"`
 	TotalCount int64     `json:"totalCount"`
 }
 
 // PaginatedTokens is a list of tokens as well as the explicit total count
 // field.
 type PaginatedTokens struct {
-	Tokens     []Token `json:"tokens"`
+	List       []Token `json:"list"`
 	TotalCount int64   `json:"totalCount"`
 }
 
 // PaginatedProviders is a list of providers as well as the explicit total count
 // field.
 type PaginatedProviders struct {
-	Providers  []Provider `json:"providers"`
+	List       []Provider `json:"list"`
 	TotalCount int64      `json:"totalCount"`
 }
 
 // PaginatedProviders is a list of providers as well as the explicit total count
 // field.
 type PaginatedTestResultDetails struct {
-	Details    []TestResultDetail `json:"details"`
+	List       []TestResultDetail `json:"list"`
 	TotalCount int64              `json:"totalCount"`
 }
 
 // PaginatedProviders is a list of providers as well as the explicit total count
 // field.
 type PaginatedTestResultSummaries struct {
-	Summaries  []TestResultSummary `json:"summaries"`
+	List       []TestResultSummary `json:"list"`
 	TotalCount int64               `json:"totalCount"`
 }
 

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -174,15 +174,15 @@ type PaginatedProviders struct {
 	TotalCount int64      `json:"totalCount"`
 }
 
-// PaginatedProviders is a list of providers as well as the explicit total count
-// field.
+// PaginatedTestResultDetails is a list of test result details as well as the
+// explicit total count field.
 type PaginatedTestResultDetails struct {
 	List       []TestResultDetail `json:"list"`
 	TotalCount int64              `json:"totalCount"`
 }
 
-// PaginatedProviders is a list of providers as well as the explicit total count
-// field.
+// PaginatedTestResultSummaries is a list of test result summaries as well as
+// the explicit total count field.
 type PaginatedTestResultSummaries struct {
 	List       []TestResultSummary `json:"list"`
 	TotalCount int64               `json:"totalCount"`

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -174,6 +174,20 @@ type PaginatedProviders struct {
 	TotalCount int64      `json:"totalCount"`
 }
 
+// PaginatedProviders is a list of providers as well as the explicit total count
+// field.
+type PaginatedTestResultDetails struct {
+	Details    []TestResultDetail `json:"details"`
+	TotalCount int64              `json:"totalCount"`
+}
+
+// PaginatedProviders is a list of providers as well as the explicit total count
+// field.
+type PaginatedTestResultSummaries struct {
+	Summaries  []TestResultSummary `json:"summaries"`
+	TotalCount int64               `json:"totalCount"`
+}
+
 // Ping pongs.
 type Ping struct {
 	Message string `json:"message" example:"pong"`

--- a/project.go
+++ b/project.go
@@ -145,7 +145,7 @@ func (m projectModule) getProjectListHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response.PaginatedProjects{
-		Projects:   modelconv.DBProjectsToResponses(dbProjects),
+		List:       modelconv.DBProjectsToResponses(dbProjects),
 		TotalCount: totalCount,
 	})
 }

--- a/provider.go
+++ b/provider.go
@@ -113,7 +113,7 @@ func (m providerModule) getProviderListHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response.PaginatedProviders{
-		Providers:  modelconv.DBProvidersToResponses(dbProviders),
+		List:       modelconv.DBProvidersToResponses(dbProviders),
 		TotalCount: totalCount,
 	})
 }

--- a/test_result.go
+++ b/test_result.go
@@ -126,7 +126,7 @@ func (m buildTestResultModule) createBuildTestResultHandler(c *gin.Context) {
 // @summary Get all test result details for specified build
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
-// @success 200 {object} []response.TestResultDetail
+// @success 200 {object} response.PaginatedTestResultDetails
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/test-result/detail [get]
@@ -150,7 +150,10 @@ func (m buildTestResultModule) getBuildAllTestResultDetailListHandler(c *gin.Con
 	}
 
 	resDetails := modelconv.DBTestResultDetailsToResponses(dbDetails)
-	c.JSON(http.StatusOK, resDetails)
+	c.JSON(http.StatusOK, response.PaginatedTestResultDetails{
+		Details:    resDetails,
+		TotalCount: int64(len(resDetails)),
+	})
 }
 
 // getBuildAllTestResultSummaryListHandler godoc
@@ -158,7 +161,7 @@ func (m buildTestResultModule) getBuildAllTestResultDetailListHandler(c *gin.Con
 // @summary Get all test result summaries for specified build
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
-// @success 200 {object} []response.TestResultSummary
+// @success 200 {object} response.PaginatedTestResultSummaries
 // @failure 400 {object} problem.Response "Bad Request"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/test-result/summary [get]
@@ -186,7 +189,10 @@ func (m buildTestResultModule) getBuildAllTestResultSummaryListHandler(c *gin.Co
 		resSummaries[i] = modelconv.DBTestResultSummaryToResponse(dbSummary)
 	}
 
-	c.JSON(http.StatusOK, resSummaries)
+	c.JSON(http.StatusOK, response.PaginatedTestResultSummaries{
+		Summaries:  resSummaries,
+		TotalCount: int64(len(resSummaries)),
+	})
 }
 
 // getBuildTestResultSummaryHandler godoc
@@ -233,7 +239,7 @@ func (m buildTestResultModule) getBuildTestResultSummaryHandler(c *gin.Context) 
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @param artifactId path uint true "Artifact ID" minimum(0)
-// @success 200 {object} []response.TestResultDetail
+// @success 200 {object} response.PaginatedTestResultDetails
 // @failure 400 {object} problem.Response "Bad Request"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /build/{buildId}/test-result/summary/{artifactId}/detail [get]
@@ -262,7 +268,10 @@ func (m buildTestResultModule) getBuildTestResultDetailListHandler(c *gin.Contex
 	}
 
 	resDetails := modelconv.DBTestResultDetailsToResponses(dbDetails)
-	c.JSON(http.StatusOK, resDetails)
+	c.JSON(http.StatusOK, response.PaginatedTestResultDetails{
+		Details:    resDetails,
+		TotalCount: int64(len(dbDetails)),
+	})
 }
 
 // getBuildAllTestResultListSummaryHandler godoc

--- a/test_result.go
+++ b/test_result.go
@@ -151,7 +151,7 @@ func (m buildTestResultModule) getBuildAllTestResultDetailListHandler(c *gin.Con
 
 	resDetails := modelconv.DBTestResultDetailsToResponses(dbDetails)
 	c.JSON(http.StatusOK, response.PaginatedTestResultDetails{
-		Details:    resDetails,
+		List:       resDetails,
 		TotalCount: int64(len(resDetails)),
 	})
 }
@@ -190,7 +190,7 @@ func (m buildTestResultModule) getBuildAllTestResultSummaryListHandler(c *gin.Co
 	}
 
 	c.JSON(http.StatusOK, response.PaginatedTestResultSummaries{
-		Summaries:  resSummaries,
+		List:       resSummaries,
 		TotalCount: int64(len(resSummaries)),
 	})
 }
@@ -269,7 +269,7 @@ func (m buildTestResultModule) getBuildTestResultDetailListHandler(c *gin.Contex
 
 	resDetails := modelconv.DBTestResultDetailsToResponses(dbDetails)
 	c.JSON(http.StatusOK, response.PaginatedTestResultDetails{
-		Details:    resDetails,
+		List:       resDetails,
 		TotalCount: int64(len(dbDetails)),
 	})
 }

--- a/token.go
+++ b/token.go
@@ -98,7 +98,7 @@ func (m tokenModule) getTokenListHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response.PaginatedTokens{
-		Tokens:     modelconv.DBTokensToResponses(dbTokens),
+		List:       modelconv.DBTokensToResponses(dbTokens),
 		TotalCount: totalCount,
 	})
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed test_result.go to use paginated responses
- Renamed slice field in paginated response to only be "list"

## Motivation

Having the fields be named differently is just a hassle if your client supports any kind of generics. While Go doesn't, we don't want to be an easily avoidable annoyance.

Changing the test_result.go endpoints was brought up in discussion <https://github.com/iver-wharf/wharf-api/pull/109#issuecomment-966894215>, and was done to keep consistency with the other GET endpoints
