### PR TITLE
Fixed PaginatedBuilds in deprecated getProjectBuildListHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Deprecated POST search endpoints that took the search queries from the HTTP
   request body. They are still supported, but may be removed in the next major
   release (v6.0.0). Please refer to the new endpoints that use query parameter
-  instead. (#99, #109)
+  instead. (#99, #109, #118, #119)
 
   - Use new `GET /project` instead of `GET /projects` or `POST /projects/search`
   - Use new `GET /build` instead of `GET /projects/{projectId}/builds` or `POST /builds/search`

--- a/internal/deprecated/project.go
+++ b/internal/deprecated/project.go
@@ -142,6 +142,12 @@ var buildJSONToColumns = map[string]database.SafeSQLName{
 	response.BuildJSONFields.IsInvalid:   database.BuildColumns.IsInvalid,
 }
 
+// PaginatedBuilds is a list of builds as well as an explicit total count field.
+type PaginatedBuilds struct {
+	Builds     []response.Build `json:"builds"`
+	TotalCount int64            `json:"totalCount"`
+}
+
 // getProjectBuildListHandler godoc
 // @id oldGetProjectBuildList
 // @deprecated
@@ -153,7 +159,7 @@ var buildJSONToColumns = map[string]database.SafeSQLName{
 // @param limit query string true "number of fetched branches"
 // @param offset query string true "PK of last branch taken"
 // @param orderby query []string false "Sorting orders. Takes the property name followed by either 'asc' or 'desc'. Can be specified multiple times for more granular sorting. Defaults to `?orderby=buildId desc`"
-// @success 200 {object} response.PaginatedBuilds
+// @success 200 {object} PaginatedBuilds
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
@@ -198,8 +204,8 @@ func (m ProjectModule) getProjectBuildListHandler(c *gin.Context) {
 		return
 	}
 
-	resPaginated := response.PaginatedBuilds{
-		List:       modelconv.DBBuildsToResponses(dbBuilds),
+	resPaginated := PaginatedBuilds{
+		Builds:     modelconv.DBBuildsToResponses(dbBuilds),
 		TotalCount: count,
 	}
 	c.JSON(http.StatusOK, resPaginated)


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed to use deprecated.PaginatedBuilds instead of response.PaginatedBuilds, taken from v4.2.0, where array field was named `builds` and not `list`

## Motivation

PR #118 changed the array field in the paginated results to be named `list` instead of the name of the type.

This broke backward compatibility. This PR restores that
