### PR TITLE
Move endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - Use new `GET /token` instead of `GET /tokens` or `POST /tokens/search`
   - Use new `GET /build/{buildId}/artifact` instead of `GET /build/{buildId}/artifacts`
 
+- Deprecated `/branch` and `/branches` endpoints in favor of
+  new `/project/{projectId}/branch` endpoints. (#120)
+
+- Deprecated `PUT /build/{buildId}` in favor of new `PUT /build/{buildId}/status`
+  endpoint. (#120)
+
+- Deprecated `POST /project/{projectId}/{stage}/run` in favor of
+  new `POST /project/{projectId}/build` endpoint. (#120)
+
 - Added new GET endpoints to get list of objects (as mentioned in note above),
   with large set of query parameters. Major difference with their "plural"
   GET counterparts, they all return paginated results instead, as well as a

--- a/branch.go
+++ b/branch.go
@@ -20,33 +20,30 @@ type branchModule struct {
 }
 
 func (m branchModule) Register(g *gin.RouterGroup) {
-	branches := g.Group("/branches")
-	{
-		branches.GET("", m.getBranchListHandler)
-	}
-
 	branch := g.Group("/branch")
 	{
-		branch.POST("", m.createBranchHandler)
+		branch.POST("", m.createProjectBranchHandler)
 	}
 
 	projectBranch := g.Group("/project/:projectId/branch")
 	{
+		projectBranch.GET("", m.getProjectBranchListHandler)
 		projectBranch.PUT("", m.updateProjectBranchListHandler)
 	}
 }
 
-// getBranchListHandler godoc
+// getProjectBranchListHandler godoc
 // @id getBranchList
 // @summary NOT IMPLEMENTED YET
 // @tags branch
+// @param projectId path uint true "project ID" minimum(0)
 // @success 501 "Not Implemented"
-// @router /branches [get]
-func (m branchModule) getBranchListHandler(c *gin.Context) {
+// @router /project/{projectId}/branch [get]
+func (m branchModule) getProjectBranchListHandler(c *gin.Context) {
 	c.Status(http.StatusNotImplemented)
 }
 
-// createBranchHandler godoc
+// createProjectBranchHandler godoc
 // @id createBranch
 // @summary Create or update branch.
 // @description It finds branch by project ID, token ID and name.
@@ -56,13 +53,9 @@ func (m branchModule) getBranchListHandler(c *gin.Context) {
 // @accept json
 // @produce json
 // @param branch body request.Branch true "branch object"
-// @success 200 {object} response.Branch "Updated branch"
-// @success 201 {object} response.Branch "Added new branch"
-// @failure 400 {object} problem.Response "Bad request"
-// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
-// @failure 502 {object} problem.Response "Database is unreachable"
-// @router /branch [post]
-func (m branchModule) createBranchHandler(c *gin.Context) {
+// @success 501 "Not Implemented"
+// @router /project/{projectId}/branch [post]
+func (m branchModule) createProjectBranchHandler(c *gin.Context) {
 	var reqBranch request.Branch
 	if err := c.ShouldBindJSON(&reqBranch); err != nil {
 		ginutil.WriteInvalidBindError(c, err,

--- a/branch.go
+++ b/branch.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/iver-wharf/wharf-api/internal/ptrconv"
@@ -20,21 +18,17 @@ type branchModule struct {
 }
 
 func (m branchModule) Register(g *gin.RouterGroup) {
-	branch := g.Group("/branch")
-	{
-		branch.POST("", m.createProjectBranchHandler)
-	}
-
 	projectBranch := g.Group("/project/:projectId/branch")
 	{
 		projectBranch.GET("", m.getProjectBranchListHandler)
 		projectBranch.PUT("", m.updateProjectBranchListHandler)
+		projectBranch.POST("", m.createProjectBranchHandler)
 	}
 }
 
 // getProjectBranchListHandler godoc
-// @id getBranchList
-// @summary NOT IMPLEMENTED YET
+// @id getProjectBranchList
+// @summary Get list of branches. (NOT IMPLEMENTED!)
 // @tags branch
 // @param projectId path uint true "project ID" minimum(0)
 // @success 501 "Not Implemented"
@@ -44,56 +38,17 @@ func (m branchModule) getProjectBranchListHandler(c *gin.Context) {
 }
 
 // createProjectBranchHandler godoc
-// @id createBranch
-// @summary Create or update branch.
-// @description It finds branch by project ID, token ID and name.
-// @description First found branch will have updated default flag.
-// @description If not existing new branch will be created.
+// @id createProjectBranch
+// @summary Add branch to project. (NOT IMPLEMENTED!)
+// @description Adds a branch to the project, and allows you to set this new branch to be the default branch.
 // @tags branch
 // @accept json
 // @produce json
-// @param branch body request.Branch true "branch object"
+// @param branch body request.Branch true "Branch object"
 // @success 501 "Not Implemented"
 // @router /project/{projectId}/branch [post]
 func (m branchModule) createProjectBranchHandler(c *gin.Context) {
-	var reqBranch request.Branch
-	if err := c.ShouldBindJSON(&reqBranch); err != nil {
-		ginutil.WriteInvalidBindError(c, err,
-			"One or more parameters failed to parse when reading the request body for branch object to update.")
-		return
-	}
-
-	dbBranch := database.Branch{
-		ProjectID: reqBranch.ProjectID,
-		TokenID:   reqBranch.TokenID,
-		Name:      reqBranch.Name,
-		Default:   reqBranch.Default,
-	}
-
-	var dbExistingBranch database.Branch
-	err := m.Database.
-		Where(&dbBranch, database.BranchFields.ProjectID, database.BranchFields.TokenID, database.BranchFields.Name).
-		First(&dbExistingBranch).
-		Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		if err := m.Database.Create(&dbBranch).Error; err != nil {
-			ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
-				"Failed creating branch with name %q for token with ID %d and for project with ID %d in database.",
-				dbBranch.Name, dbBranch.TokenID, dbBranch.ProjectID))
-			return
-		}
-		c.JSON(http.StatusCreated, modelconv.DBBranchToResponse(dbBranch))
-		return
-	} else if err != nil {
-		ginutil.WriteDBReadError(c, err, fmt.Sprintf(
-			"Failed fetching branch with name %q for token with ID %d and for project with ID %d in database.",
-			reqBranch.Name, reqBranch.TokenID, reqBranch.ProjectID))
-		return
-	}
-
-	dbExistingBranch.Default = reqBranch.Default
-	m.Database.Save(dbExistingBranch)
-	c.JSON(http.StatusOK, modelconv.DBBranchToResponse(dbExistingBranch))
+	c.Status(http.StatusNotImplemented)
 }
 
 // updateProjectBranchListHandler godoc

--- a/build.go
+++ b/build.go
@@ -41,7 +41,7 @@ func (m buildModule) Register(g *gin.RouterGroup) {
 		buildByID := build.Group("/:buildId")
 		{
 			buildByID.GET("", m.getBuildHandler)
-			buildByID.PUT("", m.updateBuildHandler)
+			buildByID.PUT("/status", m.updateBuildStatusHandler)
 			buildByID.POST("/log", m.createBuildLogHandler)
 			buildByID.GET("/log", m.getBuildLogListHandler)
 			buildByID.GET("/stream", m.streamBuildLogHandler)
@@ -376,51 +376,15 @@ func (m buildModule) createBuildLogHandler(c *gin.Context) {
 	c.Status(http.StatusCreated)
 }
 
-// updateBuildHandler godoc
-// @id updateBuild
-// @summary Partially update specific build
+// updateBuildStatusHandler godoc
+// @id updateBuildStatus
+// @summary Update a build's status. (NOT IMPLEMENTED!)
 // @tags build
-// @param buildId path uint true "build id" minimum(0)
-// @param status query string true "Build status term" Enums(Scheduling, Running, Completed, Failed)
-// @success 200 {object} response.Build
-// @failure 400 {object} problem.Response "Bad request"
-// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
-// @failure 404 {object} problem.Response "Build not found"
-// @failure 502 {object} problem.Response "Database is unreachable"
-// @router /build/{buildId} [put]
-func (m buildModule) updateBuildHandler(c *gin.Context) {
-	buildID, ok := ginutil.ParseParamUint(c, "buildId")
-	if !ok {
-		return
-	}
-
-	status, ok := ginutil.RequireQueryString(c, "status")
-	if !ok {
-		return
-	}
-
-	statusID, ok := modelconv.ReqBuildStatusToDatabase(request.BuildStatus(status))
-	if !ok {
-		ginutil.WriteInvalidParamError(c, nil, "status", fmt.Sprintf(
-			"Unable to parse build status from %q", status))
-		return
-	}
-
-	dbBuild, err := m.updateBuildStatus(buildID, statusID)
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		ginutil.WriteDBNotFound(c, fmt.Sprintf(
-			"Build with ID %d was not found when trying to update status to %q.",
-			buildID, status))
-		return
-	} else if err != nil {
-		ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
-			"Failed updating build status to %q on build with ID %d in the database.",
-			status, buildID))
-		return
-	}
-
-	resBuild := modelconv.DBBuildToResponse(dbBuild)
-	c.JSON(http.StatusOK, resBuild)
+// @param buildId path uint true "Build ID" minimum(0)
+// @success 501 "Not Implemented"
+// @router /build/{buildId}/status [put]
+func (m buildModule) updateBuildStatusHandler(c *gin.Context) {
+	c.Status(http.StatusNotImplemented)
 }
 
 func (m buildModule) updateBuildStatus(buildID uint, statusID database.BuildStatus) (database.Build, error) {

--- a/build.go
+++ b/build.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"strconv"
+	"strings"
 	"time"
 
 	"net/http"
+	"net/url"
 
 	"github.com/dustin/go-broadcast"
+	"github.com/ghodss/yaml"
 	"github.com/gin-gonic/gin"
 	"github.com/iver-wharf/wharf-api/internal/wherefields"
 	"github.com/iver-wharf/wharf-api/pkg/model/database"
@@ -17,11 +23,14 @@ import (
 	"github.com/iver-wharf/wharf-api/pkg/modelconv"
 	"github.com/iver-wharf/wharf-api/pkg/orderby"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
+	"github.com/iver-wharf/wharf-core/pkg/problem"
+	"gopkg.in/guregu/null.v4"
 	"gorm.io/gorm"
 )
 
 type buildModule struct {
 	Database *gorm.DB
+	Config   *Config
 }
 
 func (m buildModule) Register(g *gin.RouterGroup) {
@@ -43,6 +52,12 @@ func (m buildModule) Register(g *gin.RouterGroup) {
 			buildTestResults := buildTestResultModule{m.Database}
 			buildTestResults.Register(buildByID)
 		}
+	}
+	projectByID := g.Group("/project/:projectId")
+	{
+		projectByID.POST("/build", m.startProjectBuildHandler)
+		// Deprecated:
+		projectByID.POST("/:stage/run", m.oldStartProjectBuildHandler)
 	}
 }
 
@@ -483,4 +498,323 @@ func (m buildModule) getLogs(buildID uint) ([]database.Log, error) {
 		return []database.Log{}, err
 	}
 	return dbLogs, nil
+}
+
+// oldStartProjectBuildHandler godoc
+// @id oldStartProjectBuild
+// @deprecated
+// @summary Responsible for run stage environment for selected project
+// @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
+// @description Use `POST /project/{projectId}/build` instead.
+// @tags project
+// @accept json
+// @param projectId path uint true "project ID" minimum(0)
+// @param stage path string true "name of stage to run, or specify ALL to run everything"
+// @param branch query string false "branch name, uses default branch if omitted"
+// @param environment query string false "environment name"
+// @param inputs body string _ "user inputs" example(foo:bar)
+// @success 200 {object} response.BuildReferenceWrapper "Build scheduled"
+// @failure 400 {object} problem.Response "Bad request, such as invalid body JSON"
+// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
+// @failure 404 {object} problem.Response "Project was not found"
+// @failure 502 {object} problem.Response "Database or code execution engine is unreachable"
+// @router /project/{projectId}/{stage}/run [post]
+func (m buildModule) oldStartProjectBuildHandler(c *gin.Context) {
+	// not moved to `internal/deprecated` package as it's too much
+	// code duplication
+	projectID, ok := ginutil.ParseParamUint(c, "projectId")
+	if !ok {
+		return
+	}
+	stageName := c.Param("stage")
+	m.startBuildHandler(c, projectID, stageName)
+}
+
+// startProjectBuildHandler godoc
+// @id startProjectBuild
+// @summary Start a new build for the given project, with optional build stage, build environment, or repo branch filters.
+// @tags build
+// @accept json
+// @param projectId path uint true "Project ID" minimum(0)
+// @param stage query string false "Name of stage to run, or specify `ALL` to run all stages." default(ALL)
+// @param branch query string false "Branch name. Uses project's default branch if omitted"
+// @param environment query string false "Environment name filter. If left empty it will run all stages without any environment filters."
+// @param inputs body request.BuildInputs _ "Input variable values. Map of variable names (as defined in the project's `.wharf-ci.yml` file) as keys paired with their string, boolean, or numeric value."
+// @success 200 {object} response.BuildReferenceWrapper "Build scheduled"
+// @failure 400 {object} problem.Response "Bad request, such as invalid body JSON"
+// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
+// @failure 404 {object} problem.Response "Project was not found"
+// @failure 502 {object} problem.Response "Database or code execution engine is unreachable"
+// @router /project/{projectId}/build [post]
+func (m buildModule) startProjectBuildHandler(c *gin.Context) {
+	projectID, ok := ginutil.ParseParamUint(c, "projectId")
+	if !ok {
+		return
+	}
+	stageName, hasStageName := c.GetQuery("stage")
+	if !hasStageName {
+		stageName = "ALL"
+	}
+	m.startBuildHandler(c, projectID, stageName)
+}
+
+func (m buildModule) startBuildHandler(c *gin.Context, projectID uint, stageName string) {
+	dbProject, ok := fetchProjectByID(c, m.Database, projectID, "when starting a new build")
+	if !ok {
+		return
+	}
+
+	body, err := c.GetRawData()
+	if err != nil {
+		ginutil.WriteBodyReadError(c, err, fmt.Sprintf(
+			"Failed to read the input variables body when starting a new build for project with ID %d.",
+			projectID))
+		return
+	}
+
+	env, hasEnv := c.GetQuery("environment")
+	branch, hasBranch := c.GetQuery("branch")
+
+	if !hasBranch {
+		b, ok := findDefaultBranch(dbProject.Branches)
+		if !ok {
+			ginutil.WriteDBNotFound(c, fmt.Sprintf(
+				"No branch to build for project with ID %d was specified, and no default branch was found on the project.",
+				projectID))
+			return
+		}
+		branch = b.Name
+	}
+
+	now := time.Now().UTC()
+	dbBuild := database.Build{
+		ProjectID:   dbProject.ProjectID,
+		ScheduledOn: null.TimeFrom(now),
+		GitBranch:   branch,
+		Environment: null.NewString(env, hasEnv),
+		Stage:       stageName,
+	}
+	if err := m.Database.Create(&dbBuild).Error; err != nil {
+		ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
+			"Failed creating build on stage %q and branch %q for project with ID %d in database.",
+			stageName, branch, projectID))
+		return
+	}
+
+	dbBuildParams, err := parseDBBuildParams(dbBuild.BuildID, []byte(dbProject.BuildDefinition), body)
+	if err != nil {
+		dbBuild.IsInvalid = true
+		if saveErr := m.Database.Save(&dbBuild).Error; saveErr != nil {
+			c.Error(saveErr)
+		}
+		ginutil.WriteProblemError(c, err, problem.Response{
+			Type:   "/prob/api/project/run/params-deserialize",
+			Title:  "Parsing build parameters failed.",
+			Status: http.StatusBadRequest,
+			Detail: fmt.Sprintf(
+				"Failed to deserialize build parameters from request body for build on stage %q and branch %q for project with ID %d.",
+				stageName, branch, projectID),
+		})
+		return
+	}
+
+	err = m.SaveBuildParams(dbBuildParams)
+	if err != nil {
+		dbBuild.IsInvalid = true
+		if saveErr := m.Database.Save(&dbBuild).Error; saveErr != nil {
+			c.Error(saveErr)
+		}
+		ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
+			"Failed saving build parameters for build on stage %q and branch %q for project with ID %d in database.",
+			stageName, branch, projectID))
+		return
+	}
+
+	dbJobParams, err := getDBJobParams(dbProject, dbBuild, dbBuildParams, m.Config.InstanceID)
+	if err != nil {
+		dbBuild.IsInvalid = true
+		if saveErr := m.Database.Save(&dbBuild).Error; saveErr != nil {
+			c.Error(saveErr)
+		}
+		ginutil.WriteProblemError(c, err, problem.Response{
+			Type:   "/prob/api/project/run/params-serialize",
+			Title:  "Serializing build parameters failed.",
+			Status: http.StatusBadRequest,
+			Detail: fmt.Sprintf(
+				"Failed to serialize build parameters before sending them onwards to Wharfs execution engine for build on stage %q and branch %q for project with ID %d.",
+				stageName, branch, projectID),
+		})
+		return
+	}
+
+	if m.Config.CI.MockTriggerResponse {
+		log.Info().Message("Setting for mocking build triggers was true, mocking CI response.")
+		c.JSON(http.StatusOK, modelconv.DBBuildToResponseBuildReferenceWrapper(dbBuild))
+		return
+	}
+
+	_, err = triggerBuild(dbJobParams, m.Config.CI)
+	if err != nil {
+		dbBuild.IsInvalid = true
+		if saveErr := m.Database.Save(&dbBuild).Error; saveErr != nil {
+			c.Error(saveErr)
+		}
+
+		ginutil.WriteProblemError(c, err, problem.Response{
+			Type:   "/prob/api/project/run/trigger",
+			Title:  "Triggering build failed.",
+			Status: http.StatusBadGateway,
+			Detail: fmt.Sprintf(
+				"Failed to trigger code execution engine to schedule the build with ID %d on stage %q on branch %q for project with ID %d.",
+				dbBuild.BuildID, stageName, branch, projectID),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, modelconv.DBBuildToResponseBuildReferenceWrapper(dbBuild))
+}
+
+func (m buildModule) SaveBuildParams(dbParams []database.BuildParam) error {
+	for _, dbParam := range dbParams {
+		if err := m.Database.Create(&dbParam).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parseDBBuildParams(buildID uint, buildDef []byte, vars []byte) ([]database.BuildParam, error) {
+	type BuildDefinition struct {
+		Inputs []struct {
+			Name    string
+			Type    string
+			Default string
+		}
+	}
+
+	var def BuildDefinition
+	err := yaml.Unmarshal(buildDef, &def)
+	if err != nil {
+		log.Error().WithError(err).Message("Failed unmarshaling build-def.")
+		return nil, err
+	}
+
+	log.Info().
+		WithInt("inputs", len(def.Inputs)).
+		Message("Unmarshaled build-def.")
+
+	m := make(request.BuildInputs)
+	err = json.Unmarshal(vars, &m)
+	if err != nil {
+		log.Error().WithError(err).Message("Failed unmarshaling input variables JSON.")
+		return nil, err
+	}
+
+	var params []database.BuildParam
+	for _, input := range def.Inputs {
+		param := database.BuildParam{
+			Name:    input.Name,
+			BuildID: buildID,
+		}
+
+		if m[input.Name] == nil {
+			param.Value = input.Default
+		} else {
+			param.Value = fmt.Sprintf("%v", m[input.Name])
+		}
+
+		params = append(params, param)
+	}
+
+	return params, nil
+}
+
+func triggerBuild(dbJobParams []database.Param, conf CIConfig) (string, error) {
+	q := ""
+	for _, dbJobParam := range dbJobParams {
+		if dbJobParam.Value != "" {
+			q = fmt.Sprintf("%s&%s=%s", q, url.QueryEscape(dbJobParam.Name), url.QueryEscape(dbJobParam.Value))
+		}
+	}
+
+	tokenStr := fmt.Sprintf("?token=%s", conf.TriggerToken)
+
+	url := fmt.Sprintf("%s%s%s", conf.TriggerURL, tokenStr, q)
+	fmt.Printf("POSTing to url: %v\n", url)
+	log.Info().
+		WithString("method", "POST").
+		WithString("url", fmt.Sprintf("%s?token=%s%s", conf.TriggerURL, "*****", q)).
+		Message("Triggering build.")
+
+	var resp, err = http.Post(url, "", nil)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+	var body, err2 = ioutil.ReadAll(resp.Body)
+	if err2 != nil {
+		return "", err2
+	}
+
+	var strBody = string(body)
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		return "", fmt.Errorf(strBody)
+	}
+
+	return strBody, err2
+}
+
+func getDBJobParams(
+	dbProject database.Project,
+	dbBuild database.Build,
+	dbBuildParams []database.BuildParam,
+	wharfInstanceID string,
+) ([]database.Param, error) {
+	var err error
+	var v []byte
+	if len(dbBuildParams) > 0 {
+		m := make(map[string]interface{})
+
+		for _, input := range dbBuildParams {
+			m[input.Name] = input.Value
+		}
+
+		v, err = yaml.Marshal(m)
+		if err != nil {
+			log.Error().WithError(err).Message("Failed to marshal input variables YAML for build.")
+			return nil, err
+		}
+	} else {
+		log.Debug().Message("Skipping input variables, nothing in body.")
+	}
+
+	token := ""
+	if dbProject.Token != nil {
+		token = dbProject.Token.Token
+	}
+
+	dbJobParams := []database.Param{
+		{Type: "string", Name: "REPO_NAME", Value: dbProject.Name},
+		{Type: "string", Name: "REPO_GROUP", Value: strings.ToLower(dbProject.GroupName)},
+		{Type: "string", Name: "REPO_BRANCH", Value: dbBuild.GitBranch},
+		{Type: "string", Name: "GIT_BRANCH", Value: dbBuild.GitBranch},
+		{Type: "string", Name: "RUN_STAGES", Value: dbBuild.Stage},
+		{Type: "string", Name: "BUILD_REF", Value: strconv.FormatUint(uint64(dbBuild.BuildID), 10)},
+		{Type: "string", Name: "VARS", Value: string(v)},
+		{Type: "string", Name: "GIT_FULLURL", Value: dbProject.GitURL},
+		{Type: "string", Name: "GIT_TOKEN", Value: token},
+		{Type: "string", Name: "WHARF_PROJECT_ID", Value: strconv.FormatUint(uint64(dbProject.ProjectID), 10)},
+		{Type: "string", Name: "WHARF_INSTANCE", Value: wharfInstanceID},
+	}
+
+	if dbBuild.Environment.Valid {
+		dbJobParams = append(dbJobParams, database.Param{
+			Type:  "string",
+			Name:  "ENVIRONMENT",
+			Value: dbBuild.Environment.String,
+		})
+	}
+
+	return dbJobParams, nil
 }

--- a/internal/deprecated/branch.go
+++ b/internal/deprecated/branch.go
@@ -62,10 +62,11 @@ func (m BranchModule) getBranchListHandler(c *gin.Context) {
 
 // Branch specifies fields when adding a new branch to a project.
 type Branch struct {
-	ProjectID uint   `json:"projectId" validate:"required" minimum:"0"`
-	Name      string `json:"name" validate:"required"`
+	BranchID  uint   `json:"branchId"`
+	ProjectID uint   `json:"projectId"`
+	Name      string `json:"name"`
 	Default   bool   `json:"default"`
-	TokenID   uint   `json:"tokenId" minimum:"0"`
+	TokenID   uint   `json:"tokenId"`
 }
 
 // createBranchHandler godoc

--- a/internal/deprecated/branch.go
+++ b/internal/deprecated/branch.go
@@ -1,11 +1,12 @@
 package deprecated
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/iver-wharf/wharf-api/pkg/model/database"
-	"github.com/iver-wharf/wharf-api/pkg/model/request"
 	"github.com/iver-wharf/wharf-api/pkg/modelconv"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"gorm.io/gorm"
@@ -18,12 +19,17 @@ type BranchModule struct {
 
 // Register adds all deprecated endpoints to a given Gin router group.
 func (m BranchModule) Register(g *gin.RouterGroup) {
+	branches := g.Group("/branches")
+	{
+		branches.GET("", m.getBranchListHandler)
+		branches.PUT("", m.updateProjectBranchListHandler)
+	}
+
 	branch := g.Group("/branch")
 	{
 		branch.GET("/:branchId", m.GetBranchHandler)
+		branch.POST("", m.createBranchHandler)
 	}
-
-	g.PUT("/branches", m.updateProjectBranchListHandler)
 }
 
 // GetBranchHandler godoc
@@ -40,6 +46,88 @@ func (m BranchModule) GetBranchHandler(c *gin.Context) {
 	c.Status(http.StatusNotImplemented)
 }
 
+// getBranchListHandler godoc
+// @deprecated
+// @id oldGetBranchList
+// @description This endpoint was never implemented!
+// @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
+// @description Use `GET /project/{projectId}/branch` instead.
+// @summary NOT IMPLEMENTED
+// @tags branch
+// @success 501 "Not Implemented"
+// @router /branches [get]
+func (m BranchModule) getBranchListHandler(c *gin.Context) {
+	c.Status(http.StatusNotImplemented)
+}
+
+// Branch specifies fields when adding a new branch to a project.
+type Branch struct {
+	ProjectID uint   `json:"projectId" validate:"required" minimum:"0"`
+	Name      string `json:"name" validate:"required"`
+	Default   bool   `json:"default"`
+	TokenID   uint   `json:"tokenId" minimum:"0"`
+}
+
+// createBranchHandler godoc
+// @deprecated
+// @id oldCreateBranch
+// @summary Create or update branch.
+// @description It finds branch by project ID, token ID and name.
+// @description First found branch will have updated default flag.
+// @description If not existing new branch will be created.
+// @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
+// @description Use `PUT /project/{projectId}/branch` instead.
+// @tags branch
+// @accept json
+// @produce json
+// @param branch body deprecated.Branch true "branch object"
+// @success 200 {object} response.Branch "Updated branch"
+// @success 201 {object} response.Branch "Added new branch"
+// @failure 400 {object} problem.Response "Bad request"
+// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
+// @failure 502 {object} problem.Response "Database is unreachable"
+// @router /branch [post]
+func (m BranchModule) createBranchHandler(c *gin.Context) {
+	var reqBranch Branch
+	if err := c.ShouldBindJSON(&reqBranch); err != nil {
+		ginutil.WriteInvalidBindError(c, err,
+			"One or more parameters failed to parse when reading the request body for branch object to update.")
+		return
+	}
+
+	dbBranch := database.Branch{
+		ProjectID: reqBranch.ProjectID,
+		TokenID:   reqBranch.TokenID,
+		Name:      reqBranch.Name,
+		Default:   reqBranch.Default,
+	}
+
+	var dbExistingBranch database.Branch
+	err := m.Database.
+		Where(&dbBranch, database.BranchFields.ProjectID, database.BranchFields.TokenID, database.BranchFields.Name).
+		First(&dbExistingBranch).
+		Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		if err := m.Database.Create(&dbBranch).Error; err != nil {
+			ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
+				"Failed creating branch with name %q for token with ID %d and for project with ID %d in database.",
+				dbBranch.Name, dbBranch.TokenID, dbBranch.ProjectID))
+			return
+		}
+		c.JSON(http.StatusCreated, modelconv.DBBranchToResponse(dbBranch))
+		return
+	} else if err != nil {
+		ginutil.WriteDBReadError(c, err, fmt.Sprintf(
+			"Failed fetching branch with name %q for token with ID %d and for project with ID %d in database.",
+			reqBranch.Name, reqBranch.TokenID, reqBranch.ProjectID))
+		return
+	}
+
+	dbExistingBranch.Default = reqBranch.Default
+	m.Database.Save(dbExistingBranch)
+	c.JSON(http.StatusOK, modelconv.DBBranchToResponse(dbExistingBranch))
+}
+
 // updateProjectBranchListHandler godoc
 // @deprecated
 // @id oldUpdateProjectBranchList
@@ -50,14 +138,14 @@ func (m BranchModule) GetBranchHandler(c *gin.Context) {
 // @tags branches
 // @accept json
 // @produce json
-// @param branches body []request.Branch true "branch array"
+// @param branches body []deprecated.Branch true "branch array"
 // @success 200 {object} []response.Branch "Updated branches"
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 502 {object} problem.Response "Database is unreachable"
 // @router /branches [put]
 func (m BranchModule) updateProjectBranchListHandler(c *gin.Context) {
-	var reqBranches []request.Branch
+	var reqBranches []Branch
 	if err := c.ShouldBindJSON(&reqBranches); err != nil {
 		ginutil.WriteInvalidBindError(c, err,
 			"One or more parameters failed to parse when reading the request body for branch object array to update.")
@@ -72,7 +160,7 @@ func (m BranchModule) updateProjectBranchListHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, resBranches)
 }
 
-func (m BranchModule) replaceBranchList(reqBranches []request.Branch) ([]database.Branch, error) {
+func (m BranchModule) replaceBranchList(reqBranches []Branch) ([]database.Branch, error) {
 	var dbNewBranches []database.Branch
 
 	err := m.Database.Transaction(func(tx *gorm.DB) error {

--- a/internal/deprecated/build.go
+++ b/internal/deprecated/build.go
@@ -1,9 +1,16 @@
 package deprecated
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/iver-wharf/wharf-api/pkg/model/database"
+	"github.com/iver-wharf/wharf-api/pkg/model/request"
+	"github.com/iver-wharf/wharf-api/pkg/modelconv"
+	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"gorm.io/gorm"
 )
 
@@ -23,6 +30,7 @@ func (m BuildModule) Register(g *gin.RouterGroup) {
 	{
 		buildByID := build.Group("/:buildId")
 		{
+			buildByID.PUT("", m.updateBuildHandler)
 			artifacts := artifactModule{m.Database}
 			artifacts.Register(buildByID)
 		}
@@ -43,4 +51,108 @@ func (m BuildModule) Register(g *gin.RouterGroup) {
 // @router /builds/search [post]
 func (m BuildModule) searchBuildListHandler(c *gin.Context) {
 	c.Status(http.StatusNotImplemented)
+}
+
+// updateBuildHandler godoc
+// @id oldUpdateBuild
+// @deprecated
+// @summary Partially update specific build
+// @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
+// @description Use `PUT /build/{buildId}/status` instead.
+// @tags build
+// @param buildId path uint true "build id" minimum(0)
+// @param status query string true "Build status term" Enums(Scheduling, Running, Completed, Failed)
+// @success 200 {object} response.Build
+// @failure 400 {object} problem.Response "Bad request"
+// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
+// @failure 404 {object} problem.Response "Build not found"
+// @failure 502 {object} problem.Response "Database is unreachable"
+// @router /build/{buildId} [put]
+func (m BuildModule) updateBuildHandler(c *gin.Context) {
+	buildID, ok := ginutil.ParseParamUint(c, "buildId")
+	if !ok {
+		return
+	}
+
+	status, ok := ginutil.RequireQueryString(c, "status")
+	if !ok {
+		return
+	}
+
+	statusID, ok := modelconv.ReqBuildStatusToDatabase(request.BuildStatus(status))
+	if !ok {
+		ginutil.WriteInvalidParamError(c, nil, "status", fmt.Sprintf(
+			"Unable to parse build status from %q", status))
+		return
+	}
+
+	dbBuild, err := m.updateBuildStatus(buildID, statusID)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		ginutil.WriteDBNotFound(c, fmt.Sprintf(
+			"Build with ID %d was not found when trying to update status to %q.",
+			buildID, status))
+		return
+	} else if err != nil {
+		ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
+			"Failed updating build status to %q on build with ID %d in the database.",
+			status, buildID))
+		return
+	}
+
+	resBuild := modelconv.DBBuildToResponse(dbBuild)
+	c.JSON(http.StatusOK, resBuild)
+}
+
+func (m BuildModule) updateBuildStatus(buildID uint, statusID database.BuildStatus) (database.Build, error) {
+	if !statusID.IsValid() {
+		return database.Build{}, fmt.Errorf("invalid status ID: %+v", statusID)
+	}
+
+	dbBuild, err := m.getBuild(buildID)
+	if err != nil {
+		return database.Build{}, err
+	}
+
+	message := struct {
+		StatusBefore database.BuildStatus
+		StatusAfter  database.BuildStatus
+		Build        database.Build
+	}{
+		StatusBefore: dbBuild.StatusID,
+		StatusAfter:  statusID,
+	}
+
+	dbBuild.StatusID = statusID
+	setStatusDate(&dbBuild, statusID)
+
+	message.Build = dbBuild
+
+	if err := m.Database.Save(&dbBuild).Error; err != nil {
+		return database.Build{}, err
+	}
+
+	return dbBuild, nil
+}
+
+func (m BuildModule) getBuild(buildID uint) (database.Build, error) {
+	var dbBuild database.Build
+	if err := m.Database.
+		Where(&database.Build{BuildID: buildID}).
+		Preload(database.BuildFields.TestResultSummaries).
+		Preload(database.BuildFields.Params).
+		First(&dbBuild).
+		Error; err != nil {
+		return database.Build{}, err
+	}
+	return dbBuild, nil
+}
+
+func setStatusDate(build *database.Build, statusID database.BuildStatus) {
+	now := time.Now().UTC()
+	switch statusID {
+	case database.BuildRunning:
+		build.StartedOn.SetValid(now)
+	case database.BuildCompleted, database.BuildFailed:
+		build.CompletedOn.SetValid(now)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -113,8 +113,8 @@ func main() {
 
 	modules := []httpModule{
 		branchModule{Database: db},
-		buildModule{Database: db},
-		projectModule{Database: db, Config: &config},
+		buildModule{Database: db, Config: &config},
+		projectModule{Database: db},
 		providerModule{Database: db},
 		tokenModule{Database: db},
 		deprecated.BranchModule{Database: db},

--- a/pkg/model/request/request.go
+++ b/pkg/model/request/request.go
@@ -84,6 +84,11 @@ const (
 	BuildFailed BuildStatus = "Failed"
 )
 
+// BuildInputs is a key-value object of input variables used when starting a new
+// build, where the key is the input variable name and the value is its string,
+// boolean, or numeric value.
+type BuildInputs map[string]interface{}
+
 // Project specifies fields when creating a new project.
 type Project struct {
 	Name            string `json:"name" validate:"required" binding:"required"`

--- a/pkg/model/request/request.go
+++ b/pkg/model/request/request.go
@@ -38,10 +38,8 @@ type TokenUpdate struct {
 
 // Branch specifies fields when adding a new branch to a project.
 type Branch struct {
-	ProjectID uint   `json:"projectId" validate:"required" minimum:"0"`
-	Name      string `json:"name" validate:"required"`
-	Default   bool   `json:"default"`
-	TokenID   uint   `json:"tokenId" minimum:"0"`
+	Name    string `json:"name" validate:"required"`
+	Default bool   `json:"default"`
 }
 
 // BranchUpdate specifies fields for a single branch.

--- a/project.go
+++ b/project.go
@@ -2,18 +2,11 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 
-	"encoding/json"
 	"net/http"
-	"net/url"
 
-	"github.com/ghodss/yaml"
 	"github.com/gin-gonic/gin"
 	"github.com/iver-wharf/wharf-api/internal/ptrconv"
 	"github.com/iver-wharf/wharf-api/internal/wherefields"
@@ -22,14 +15,11 @@ import (
 	"github.com/iver-wharf/wharf-api/pkg/model/response"
 	"github.com/iver-wharf/wharf-api/pkg/modelconv"
 	"github.com/iver-wharf/wharf-api/pkg/orderby"
-	"github.com/iver-wharf/wharf-core/pkg/problem"
-	"gopkg.in/guregu/null.v4"
 	"gorm.io/gorm"
 )
 
 type projectModule struct {
 	Database *gorm.DB
-	Config   *Config
 }
 
 func (m projectModule) Register(g *gin.RouterGroup) {
@@ -42,9 +32,6 @@ func (m projectModule) Register(g *gin.RouterGroup) {
 			projectByID.GET("", m.getProjectHandler)
 			projectByID.DELETE("", m.deleteProjectHandler)
 			projectByID.PUT("", m.updateProjectHandler)
-			projectByID.POST("/build", m.startProjectBuildHandler)
-			// Deprecated:
-			projectByID.POST("/:stage/run", m.oldStartProjectBuildHandler)
 		}
 	}
 }
@@ -289,180 +276,6 @@ func (m projectModule) updateProjectHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, resProject)
 }
 
-// oldStartProjectBuildHandler godoc
-// @id oldStartProjectBuild
-// @deprecated
-// @summary Responsible for run stage environment for selected project
-// @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
-// @description Use `POST /project/{projectId}/build` instead.
-// @tags project
-// @accept json
-// @param projectId path uint true "project ID" minimum(0)
-// @param stage path string true "name of stage to run, or specify ALL to run everything"
-// @param branch query string false "branch name, uses default branch if omitted"
-// @param environment query string false "environment name"
-// @param inputs body string _ "user inputs" example(foo:bar)
-// @success 200 {object} response.BuildReferenceWrapper "Build scheduled"
-// @failure 400 {object} problem.Response "Bad request, such as invalid body JSON"
-// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
-// @failure 404 {object} problem.Response "Project was not found"
-// @failure 502 {object} problem.Response "Database or code execution engine is unreachable"
-// @router /project/{projectId}/{stage}/run [post]
-func (m projectModule) oldStartProjectBuildHandler(c *gin.Context) {
-	// not moved to `internal/deprecated` package as it's too much
-	// code duplication
-	projectID, ok := ginutil.ParseParamUint(c, "projectId")
-	if !ok {
-		return
-	}
-	stageName := c.Param("stage")
-	m.startBuild(c, projectID, stageName)
-}
-
-// startProjectBuildHandler godoc
-// @id startProjectBuild
-// @summary Start a new build for the given project, with optional build stage, build environment, or repo branch filters.
-// @tags project
-// @accept json
-// @param projectId path uint true "Project ID" minimum(0)
-// @param stage query string false "Name of stage to run, or specify `ALL` to run all stages." default(ALL)
-// @param branch query string false "Branch name. Uses project's default branch if omitted"
-// @param environment query string false "Environment name filter. If left empty it will run all stages without any environment filters."
-// @param inputs body request.BuildInputs _ "Input variable values. Map of variable names (as defined in the project's `.wharf-ci.yml` file) as keys paired with their string, boolean, or numeric value."
-// @success 200 {object} response.BuildReferenceWrapper "Build scheduled"
-// @failure 400 {object} problem.Response "Bad request, such as invalid body JSON"
-// @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
-// @failure 404 {object} problem.Response "Project was not found"
-// @failure 502 {object} problem.Response "Database or code execution engine is unreachable"
-// @router /project/{projectId}/build [post]
-func (m projectModule) startProjectBuildHandler(c *gin.Context) {
-	projectID, ok := ginutil.ParseParamUint(c, "projectId")
-	if !ok {
-		return
-	}
-	stageName, hasStageName := c.GetQuery("stage")
-	if !hasStageName {
-		stageName = "ALL"
-	}
-	m.startBuild(c, projectID, stageName)
-}
-
-func (m projectModule) startBuild(c *gin.Context, projectID uint, stageName string) {
-	dbProject, ok := fetchProjectByID(c, m.Database, projectID, "when starting a new build")
-	if !ok {
-		return
-	}
-
-	body, err := c.GetRawData()
-	if err != nil {
-		ginutil.WriteBodyReadError(c, err, fmt.Sprintf(
-			"Failed to read the input variables body when starting a new build for project with ID %d.",
-			projectID))
-		return
-	}
-
-	env, hasEnv := c.GetQuery("environment")
-	branch, hasBranch := c.GetQuery("branch")
-
-	if !hasBranch {
-		b, ok := findDefaultBranch(dbProject.Branches)
-		if !ok {
-			ginutil.WriteDBNotFound(c, fmt.Sprintf(
-				"No branch to build for project with ID %d was specified, and no default branch was found on the project.",
-				projectID))
-			return
-		}
-		branch = b.Name
-	}
-
-	now := time.Now().UTC()
-	dbBuild := database.Build{
-		ProjectID:   dbProject.ProjectID,
-		ScheduledOn: null.TimeFrom(now),
-		GitBranch:   branch,
-		Environment: null.NewString(env, hasEnv),
-		Stage:       stageName,
-	}
-	if err := m.Database.Create(&dbBuild).Error; err != nil {
-		ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
-			"Failed creating build on stage %q and branch %q for project with ID %d in database.",
-			stageName, branch, projectID))
-		return
-	}
-
-	dbBuildParams, err := parseDBBuildParams(dbBuild.BuildID, []byte(dbProject.BuildDefinition), body)
-	if err != nil {
-		dbBuild.IsInvalid = true
-		if saveErr := m.Database.Save(&dbBuild).Error; saveErr != nil {
-			c.Error(saveErr)
-		}
-		ginutil.WriteProblemError(c, err, problem.Response{
-			Type:   "/prob/api/project/run/params-deserialize",
-			Title:  "Parsing build parameters failed.",
-			Status: http.StatusBadRequest,
-			Detail: fmt.Sprintf(
-				"Failed to deserialize build parameters from request body for build on stage %q and branch %q for project with ID %d.",
-				stageName, branch, projectID),
-		})
-		return
-	}
-
-	err = m.SaveBuildParams(dbBuildParams)
-	if err != nil {
-		dbBuild.IsInvalid = true
-		if saveErr := m.Database.Save(&dbBuild).Error; saveErr != nil {
-			c.Error(saveErr)
-		}
-		ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
-			"Failed saving build parameters for build on stage %q and branch %q for project with ID %d in database.",
-			stageName, branch, projectID))
-		return
-	}
-
-	dbJobParams, err := getDBJobParams(dbProject, dbBuild, dbBuildParams, m.Config.InstanceID)
-	if err != nil {
-		dbBuild.IsInvalid = true
-		if saveErr := m.Database.Save(&dbBuild).Error; saveErr != nil {
-			c.Error(saveErr)
-		}
-		ginutil.WriteProblemError(c, err, problem.Response{
-			Type:   "/prob/api/project/run/params-serialize",
-			Title:  "Serializing build parameters failed.",
-			Status: http.StatusBadRequest,
-			Detail: fmt.Sprintf(
-				"Failed to serialize build parameters before sending them onwards to Wharfs execution engine for build on stage %q and branch %q for project with ID %d.",
-				stageName, branch, projectID),
-		})
-		return
-	}
-
-	if m.Config.CI.MockTriggerResponse {
-		log.Info().Message("Setting for mocking build triggers was true, mocking CI response.")
-		c.JSON(http.StatusOK, modelconv.DBBuildToResponseBuildReferenceWrapper(dbBuild))
-		return
-	}
-
-	_, err = triggerBuild(dbJobParams, m.Config.CI)
-	if err != nil {
-		dbBuild.IsInvalid = true
-		if saveErr := m.Database.Save(&dbBuild).Error; saveErr != nil {
-			c.Error(saveErr)
-		}
-
-		ginutil.WriteProblemError(c, err, problem.Response{
-			Type:   "/prob/api/project/run/trigger",
-			Title:  "Triggering build failed.",
-			Status: http.StatusBadGateway,
-			Detail: fmt.Sprintf(
-				"Failed to trigger code execution engine to schedule the build with ID %d on stage %q on branch %q for project with ID %d.",
-				dbBuild.BuildID, stageName, branch, projectID),
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, modelconv.DBBuildToResponseBuildReferenceWrapper(dbBuild))
-}
-
 func fetchProjectByID(c *gin.Context, db *gorm.DB, projectID uint, whenMsg string) (database.Project, bool) {
 	var dbProject database.Project
 	ok := fetchDatabaseObjByID(c, databaseProjectPreloaded(db), &dbProject, projectID, "project", whenMsg)
@@ -482,151 +295,6 @@ func databaseProjectPreloaded(db *gorm.DB) *gorm.DB {
 			return db.Order(database.BranchColumns.BranchID)
 		}).
 		Preload(database.ProjectFields.Token)
-}
-
-func (m projectModule) SaveBuildParams(dbParams []database.BuildParam) error {
-	for _, dbParam := range dbParams {
-		if err := m.Database.Create(&dbParam).Error; err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func parseDBBuildParams(buildID uint, buildDef []byte, vars []byte) ([]database.BuildParam, error) {
-	type BuildDefinition struct {
-		Inputs []struct {
-			Name    string
-			Type    string
-			Default string
-		}
-	}
-
-	var def BuildDefinition
-	err := yaml.Unmarshal(buildDef, &def)
-	if err != nil {
-		log.Error().WithError(err).Message("Failed unmarshaling build-def.")
-		return nil, err
-	}
-
-	log.Info().
-		WithInt("inputs", len(def.Inputs)).
-		Message("Unmarshaled build-def.")
-
-	m := make(request.BuildInputs)
-	err = json.Unmarshal(vars, &m)
-	if err != nil {
-		log.Error().WithError(err).Message("Failed unmarshaling input variables JSON.")
-		return nil, err
-	}
-
-	var params []database.BuildParam
-	for _, input := range def.Inputs {
-		param := database.BuildParam{
-			Name:    input.Name,
-			BuildID: buildID,
-		}
-
-		if m[input.Name] == nil {
-			param.Value = input.Default
-		} else {
-			param.Value = fmt.Sprintf("%v", m[input.Name])
-		}
-
-		params = append(params, param)
-	}
-
-	return params, nil
-}
-
-func triggerBuild(dbJobParams []database.Param, conf CIConfig) (string, error) {
-	q := ""
-	for _, dbJobParam := range dbJobParams {
-		if dbJobParam.Value != "" {
-			q = fmt.Sprintf("%s&%s=%s", q, url.QueryEscape(dbJobParam.Name), url.QueryEscape(dbJobParam.Value))
-		}
-	}
-
-	tokenStr := fmt.Sprintf("?token=%s", conf.TriggerToken)
-
-	url := fmt.Sprintf("%s%s%s", conf.TriggerURL, tokenStr, q)
-	fmt.Printf("POSTing to url: %v\n", url)
-	log.Info().
-		WithString("method", "POST").
-		WithString("url", fmt.Sprintf("%s?token=%s%s", conf.TriggerURL, "*****", q)).
-		Message("Triggering build.")
-
-	var resp, err = http.Post(url, "", nil)
-	if err != nil {
-		return "", err
-	}
-
-	defer resp.Body.Close()
-	var body, err2 = ioutil.ReadAll(resp.Body)
-	if err2 != nil {
-		return "", err2
-	}
-
-	var strBody = string(body)
-	if resp.StatusCode != 200 && resp.StatusCode != 201 {
-		return "", fmt.Errorf(strBody)
-	}
-
-	return strBody, err2
-}
-
-func getDBJobParams(
-	dbProject database.Project,
-	dbBuild database.Build,
-	dbBuildParams []database.BuildParam,
-	wharfInstanceID string,
-) ([]database.Param, error) {
-	var err error
-	var v []byte
-	if len(dbBuildParams) > 0 {
-		m := make(map[string]interface{})
-
-		for _, input := range dbBuildParams {
-			m[input.Name] = input.Value
-		}
-
-		v, err = yaml.Marshal(m)
-		if err != nil {
-			log.Error().WithError(err).Message("Failed to marshal input variables YAML for build.")
-			return nil, err
-		}
-	} else {
-		log.Debug().Message("Skipping input variables, nothing in body.")
-	}
-
-	token := ""
-	if dbProject.Token != nil {
-		token = dbProject.Token.Token
-	}
-
-	dbJobParams := []database.Param{
-		{Type: "string", Name: "REPO_NAME", Value: dbProject.Name},
-		{Type: "string", Name: "REPO_GROUP", Value: strings.ToLower(dbProject.GroupName)},
-		{Type: "string", Name: "REPO_BRANCH", Value: dbBuild.GitBranch},
-		{Type: "string", Name: "GIT_BRANCH", Value: dbBuild.GitBranch},
-		{Type: "string", Name: "RUN_STAGES", Value: dbBuild.Stage},
-		{Type: "string", Name: "BUILD_REF", Value: strconv.FormatUint(uint64(dbBuild.BuildID), 10)},
-		{Type: "string", Name: "VARS", Value: string(v)},
-		{Type: "string", Name: "GIT_FULLURL", Value: dbProject.GitURL},
-		{Type: "string", Name: "GIT_TOKEN", Value: token},
-		{Type: "string", Name: "WHARF_PROJECT_ID", Value: strconv.FormatUint(uint64(dbProject.ProjectID), 10)},
-		{Type: "string", Name: "WHARF_INSTANCE", Value: wharfInstanceID},
-	}
-
-	if dbBuild.Environment.Valid {
-		dbJobParams = append(dbJobParams, database.Param{
-			Type:  "string",
-			Name:  "ENVIRONMENT",
-			Value: dbBuild.Environment.String,
-		})
-	}
-
-	return dbJobParams, nil
 }
 
 func (m projectModule) getBuildsCount(projectID uint) (int64, error) {

--- a/project.go
+++ b/project.go
@@ -43,6 +43,7 @@ func (m projectModule) Register(g *gin.RouterGroup) {
 			projectByID.DELETE("", m.deleteProjectHandler)
 			projectByID.PUT("", m.updateProjectHandler)
 			projectByID.POST("/build", m.startProjectBuildHandler)
+			// Deprecated:
 			projectByID.POST("/:stage/run", m.oldStartProjectBuildHandler)
 		}
 	}

--- a/project.go
+++ b/project.go
@@ -320,14 +320,14 @@ func (m projectModule) oldStartProjectBuildHandler(c *gin.Context) {
 
 // startProjectBuildHandler godoc
 // @id startProjectBuild
-// @summary Responsible for run stage environment for selected project
+// @summary Start a new build for the given project, with optional build stage, build environment, or repo branch filters.
 // @tags project
 // @accept json
-// @param projectId path uint true "project ID" minimum(0)
-// @param stage query string false "name of stage to run, or specify ALL to run everything" default(ALL)
-// @param branch query string false "branch name, uses default branch if omitted"
-// @param environment query string false "environment name"
-// @param inputs body request.BuildInputs _ "user inputs"
+// @param projectId path uint true "Project ID" minimum(0)
+// @param stage query string false "Name of stage to run, or specify `ALL` to run all stages." default(ALL)
+// @param branch query string false "Branch name. Uses project's default branch if omitted"
+// @param environment query string false "Environment name filter. If left empty it will run all stages without any environment filters."
+// @param inputs body request.BuildInputs _ "Input variable values. Map of variable names (as defined in the project's `.wharf-ci.yml` file) as keys paired with their string, boolean, or numeric value."
 // @success 200 {object} response.BuildReferenceWrapper "Build scheduled"
 // @failure 400 {object} problem.Response "Bad request, such as invalid body JSON"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Moved "start build" endpoint to build.go and the `build` Swagger tag
- Deprecated all `/branch` and `/branches` endpoints in favor of `/project/{projectId}/branch` endpoints
- Deprecated `POST /project/{projectId}/{stage}/run` in favor of new `POST /project/{projectId}/build` endpoint
- Deprecated `PUT /build/{buildId}` in favor of new `PUT /build/{buildId}/status` endpoint

## Motivation

I left the new endpoints as "NOT IMPLEMENTED" to leave it to be implemented in a future PR.

Closes #14, closes #69
