### PR TITLE
Implemented endpoints from #120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,13 +53,13 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - Use new `GET /build/{buildId}/artifact` instead of `GET /build/{buildId}/artifacts`
 
 - Deprecated `/branch` and `/branches` endpoints in favor of
-  new `/project/{projectId}/branch` endpoints. (#120)
+  new `/project/{projectId}/branch` endpoints. (#120, #121)
 
 - Deprecated `PUT /build/{buildId}` in favor of new `PUT /build/{buildId}/status`
-  endpoint. (#120)
+  endpoint. (#120, #121)
 
 - Deprecated `POST /project/{projectId}/{stage}/run` in favor of
-  new `POST /project/{projectId}/build` endpoint. (#120)
+  new `POST /project/{projectId}/build` endpoint. (#120, #121)
 
 - Added new GET endpoints to get list of objects (as mentioned in note above),
   with large set of query parameters. Major difference with their "plural"

--- a/branch.go
+++ b/branch.go
@@ -67,6 +67,7 @@ func (m branchModule) getProjectBranchListHandler(c *gin.Context) {
 // @tags branch
 // @accept json
 // @produce json
+// @param projectId path uint true "project ID" minimum(0)
 // @param branch body request.Branch true "Branch object"
 // @success 200 {object} response.Branch "Updated branches"
 // @failure 400 {object} problem.Response "Bad request"

--- a/branch.go
+++ b/branch.go
@@ -246,7 +246,7 @@ func createBranchesWithNames(db *gorm.DB, projectID, tokenID uint, branchNames [
 func deleteBranchesByNames(db *gorm.DB, projectID uint, branchNames []string) error {
 	return db.
 		Where(&database.Branch{ProjectID: projectID}, database.BranchFields.ProjectID).
-		Where(database.BranchColumns.Name+" IN ?", branchNames).
+		Where(database.BranchColumns.Name+" IN ?", stringSliceToInterfaces(branchNames)).
 		Delete(&database.Branch{}).
 		Error
 }

--- a/branch.go
+++ b/branch.go
@@ -44,7 +44,7 @@ func (m branchModule) getProjectBranchListHandler(c *gin.Context) {
 	if !ok {
 		return
 	}
-	if !checkProjectExistsByID(c, m.Database, projectID, "when fetching list of branches for project") {
+	if !validateProjectExistsByID(c, m.Database, projectID, "when fetching list of branches for project") {
 		return
 	}
 	var dbBranches []database.Branch

--- a/branch.go
+++ b/branch.go
@@ -47,7 +47,9 @@ func (m branchModule) getProjectBranchListHandler(c *gin.Context) {
 		return
 	}
 	var dbBranches []database.Branch
-	err := m.Database.Where(&database.Branch{ProjectID: projectID}).Find(*&dbBranches).Error
+	err := m.Database.
+		Where(&database.Branch{ProjectID: projectID}).
+		Find(&dbBranches).Error
 	if err != nil {
 		ginutil.WriteDBReadError(c, err, fmt.Sprintf(
 			"Failed fetching list of branches for project with ID %d.",

--- a/build.go
+++ b/build.go
@@ -383,12 +383,12 @@ func (m buildModule) createBuildLogHandler(c *gin.Context) {
 // @tags build
 // @param buildId path uint true "Build ID" minimum(0)
 // @param data body request.BuildStatusUpdate true "Status update"
-// @success 201 "Updated"
+// @success 204 "Updated"
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 404 {object} problem.Response "Build not found"
 // @failure 502 {object} problem.Response "Database is unreachable"
-// @router /build/{buildId}/status [patch]
+// @router /build/{buildId}/status [put]
 func (m buildModule) updateBuildStatusHandler(c *gin.Context) {
 	buildID, ok := ginutil.ParseParamUint(c, "buildId")
 	if !ok {

--- a/build.go
+++ b/build.go
@@ -406,7 +406,7 @@ func (m buildModule) updateBuildStatusHandler(c *gin.Context) {
 			"One or more parameters failed to parse when reading the request body for build status update.")
 		return
 	}
-	if !checkBuildExistsByID(c, m.Database, buildID, "when updating build status") {
+	if !validateBuildExistsByID(c, m.Database, buildID, "when updating build status") {
 		return
 	}
 	dbBuildStatus, ok := modelconv.ReqBuildStatusToDatabase(reqStatusUpdate.Status)
@@ -825,6 +825,6 @@ func getDBJobParams(
 	return dbJobParams, nil
 }
 
-func checkBuildExistsByID(c *gin.Context, db *gorm.DB, buildID uint, whenMsg string) bool {
-	return checkDatabaseObjExistsByID(c, db, &database.Build{}, buildID, "build", whenMsg)
+func validateBuildExistsByID(c *gin.Context, db *gorm.DB, buildID uint, whenMsg string) bool {
+	return validateDatabaseObjExistsByID(c, db, &database.Build{}, buildID, "build", whenMsg)
 }

--- a/internal/deprecated/build.go
+++ b/internal/deprecated/build.go
@@ -43,7 +43,7 @@ func (m BuildModule) Register(g *gin.RouterGroup) {
 // @description This endpoint was never implemented!
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /build` instead.
-// @summary NOT IMPLEMENTED YET
+// @summary NOT IMPLEMENTED
 // @tags build
 // @accept json
 // @produce json

--- a/pkg/model/request/request.go
+++ b/pkg/model/request/request.go
@@ -82,6 +82,7 @@ const (
 	BuildFailed BuildStatus = "Failed"
 )
 
+// BuildStatusUpdate allows you to update the status of a build.
 type BuildStatusUpdate struct {
 	Status BuildStatus `json:"status" enums:"Scheduling,Running,Completed,Failed"`
 }

--- a/pkg/model/request/request.go
+++ b/pkg/model/request/request.go
@@ -82,6 +82,10 @@ const (
 	BuildFailed BuildStatus = "Failed"
 )
 
+type BuildStatusUpdate struct {
+	Status BuildStatus `json:"status" enums:",Scheduling,Running,Completed,Failed"`
+}
+
 // BuildInputs is a key-value object of input variables used when starting a new
 // build, where the key is the input variable name and the value is its string,
 // boolean, or numeric value.

--- a/pkg/model/request/request.go
+++ b/pkg/model/request/request.go
@@ -83,7 +83,7 @@ const (
 )
 
 type BuildStatusUpdate struct {
-	Status BuildStatus `json:"status" enums:",Scheduling,Running,Completed,Failed"`
+	Status BuildStatus `json:"status" enums:"Scheduling,Running,Completed,Failed"`
 }
 
 // BuildInputs is a key-value object of input variables used when starting a new

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -158,6 +158,13 @@ type PaginatedArtifacts struct {
 	TotalCount int64      `json:"totalCount"`
 }
 
+// PaginatedBranches is a list of branches as well as an explicit total count
+// field.
+type PaginatedBranches struct {
+	List       []Branch `json:"list"`
+	TotalCount int64    `json:"totalCount"`
+}
+
 // PaginatedBuilds is a list of builds as well as an explicit total count field.
 type PaginatedBuilds struct {
 	List       []Build `json:"list"`

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -161,8 +161,9 @@ type PaginatedArtifacts struct {
 // PaginatedBranches is a list of branches as well as an explicit total count
 // field.
 type PaginatedBranches struct {
-	List       []Branch `json:"list"`
-	TotalCount int64    `json:"totalCount"`
+	List          []Branch `json:"list"`
+	TotalCount    int64    `json:"totalCount"`
+	DefaultBranch *Branch  `json:"defaultBranch"`
 }
 
 // PaginatedBuilds is a list of builds as well as an explicit total count field.

--- a/pkg/modelconv/branchconv.go
+++ b/pkg/modelconv/branchconv.go
@@ -20,6 +20,19 @@ func DBBranchListToResponse(dbAllBranches []database.Branch, dbDefaultBranch *da
 	return resBranchList
 }
 
+// DBBranchListToPaginatedResponse converts a list of branches and an optional
+// default branch to a response paginated list of branches.
+func DBBranchListToPaginatedResponse(dbBranches []database.Branch, allBranchesCount int64, dbDefaultBranch *database.Branch) response.PaginatedBranches {
+	resPaginatedBranches := response.PaginatedBranches{
+		List: DBBranchesToResponses(dbBranches),
+	}
+	if dbDefaultBranch != nil {
+		resDefaultBranch := DBBranchToResponse(*dbDefaultBranch)
+		resPaginatedBranches.DefaultBranch = &resDefaultBranch
+	}
+	return resPaginatedBranches
+}
+
 // DBBranchesToResponses converts a slice of database branches to a slice of
 // response branches.
 func DBBranchesToResponses(dbBranches []database.Branch) []response.Branch {

--- a/pkg/modelconv/branchconv.go
+++ b/pkg/modelconv/branchconv.go
@@ -24,7 +24,8 @@ func DBBranchListToResponse(dbAllBranches []database.Branch, dbDefaultBranch *da
 // default branch to a response paginated list of branches.
 func DBBranchListToPaginatedResponse(dbBranches []database.Branch, allBranchesCount int64, dbDefaultBranch *database.Branch) response.PaginatedBranches {
 	resPaginatedBranches := response.PaginatedBranches{
-		List: DBBranchesToResponses(dbBranches),
+		List:       DBBranchesToResponses(dbBranches),
+		TotalCount: allBranchesCount,
 	}
 	if dbDefaultBranch != nil {
 		resDefaultBranch := DBBranchToResponse(*dbDefaultBranch)

--- a/project.go
+++ b/project.go
@@ -435,8 +435,8 @@ func fetchProjectByIDSlim(c *gin.Context, db *gorm.DB, projectID uint, whenMsg s
 	return dbProject, ok
 }
 
-func checkProjectExistsByID(c *gin.Context, db *gorm.DB, projectID uint, whenMsg string) bool {
-	return checkDatabaseObjExistsByID(c, db, &database.Project{}, projectID, "project", whenMsg)
+func validateProjectExistsByID(c *gin.Context, db *gorm.DB, projectID uint, whenMsg string) bool {
+	return validateDatabaseObjExistsByID(c, db, &database.Project{}, projectID, "project", whenMsg)
 }
 
 func databaseProjectPreloaded(db *gorm.DB) *gorm.DB {

--- a/project.go
+++ b/project.go
@@ -427,6 +427,10 @@ func fetchProjectByIDSlim(c *gin.Context, db *gorm.DB, projectID uint, whenMsg s
 	return dbProject, ok
 }
 
+func checkProjectExistsByID(c *gin.Context, db *gorm.DB, projectID uint, whenMsg string) bool {
+	return checkDatabaseObjExistsByID(c, db, &database.Project{}, projectID, "project", whenMsg)
+}
+
 func databaseProjectPreloaded(db *gorm.DB) *gorm.DB {
 	return db.Set("gorm:auto_preload", false).
 		Preload(database.ProjectFields.Provider).

--- a/utils.go
+++ b/utils.go
@@ -22,3 +22,11 @@ func findDefaultBranch(branches []database.Branch) (database.Branch, bool) {
 
 	return database.Branch{}, false
 }
+
+func stringSliceToInterfaces(values []string) []interface{} {
+	newSlice := make([]interface{}, len(values))
+	for i, v := range values {
+		newSlice[i] = v
+	}
+	return newSlice
+}

--- a/utils_gorm.go
+++ b/utils_gorm.go
@@ -36,7 +36,7 @@ func fetchDatabaseObjByID(c *gin.Context, db *gorm.DB, modelPtr interface{}, id 
 
 func checkDatabaseObjExistsByID(c *gin.Context, db *gorm.DB, modelPtr interface{}, id uint, name, whenMsg string) bool {
 	var count int64
-	if err := db.Where(modelPtr, id).Count(&count).Error; err != nil {
+	if err := db.Model(modelPtr).Where(id).Count(&count).Error; err != nil {
 		writeDBFetchObjByIDErrorProblem(c, err, id, name, whenMsg)
 		return false
 	}

--- a/utils_gorm.go
+++ b/utils_gorm.go
@@ -34,7 +34,7 @@ func fetchDatabaseObjByID(c *gin.Context, db *gorm.DB, modelPtr interface{}, id 
 	return true
 }
 
-func checkDatabaseObjExistsByID(c *gin.Context, db *gorm.DB, modelPtr interface{}, id uint, name, whenMsg string) bool {
+func validateDatabaseObjExistsByID(c *gin.Context, db *gorm.DB, modelPtr interface{}, id uint, name, whenMsg string) bool {
 	var count int64
 	if err := db.Model(modelPtr).Where(id).Count(&count).Error; err != nil {
 		writeDBFetchObjByIDErrorProblem(c, err, id, name, whenMsg)


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added checkProjectExistsByID & checkBuildExistsByID
- Implemented `GET /project/{projectId}/branch`
- Implemented `POST /project/{projectId}/branch`
- Implemented `PUT /build/{buildId}/status`
- Updated "NOT IMPLEMENTED YET" -> "NOT IMPLEMENTED" in deprecated endpoint

## Motivation

PR #120 marked some endpoints as deprecated and added new placeholder endpoints that should be used instead, but only returned "501 Not Implemented".

This PR adds implementation for them.

Closes https://github.com/iver-wharf/wharf-api/milestone/1. Yes, the final effort for RFC-0016