### PR TITLE
Document endpoint versions

### DIFF
--- a/artifact.go
+++ b/artifact.go
@@ -45,7 +45,7 @@ var defaultGetArtifactsOrderBy = orderby.Column{Name: database.ArtifactColumns.A
 // @description List all build artifacts, or a window of build artifacts using the `limit` and `offset` query parameters. Allows optional filtering parameters.
 // @description Verbatim filters will match on the entire string used to find exact matches,
 // @description while the matching filters are meant for searches by humans where it tries to find soft matches and is therefore inaccurate by nature.
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags artifact
 // @param buildId path uint true "Build ID" minimum(0)
 // @param limit query int false "Number of results to return. No limiting is applied if empty (`?limit=`) or non-positive (`?limit=0`). Required if `offset` is used." default(100)
@@ -129,7 +129,7 @@ func (m artifactModule) getBuildArtifactListHandler(c *gin.Context) {
 // getBuildArtifactHandler godoc
 // @id getBuildArtifact
 // @summary Get build artifact
-// @description Added in TODO.
+// @description Added in v0.7.1.
 // @tags artifact
 // @param buildId path uint true "Build ID" minimum(0)
 // @param artifactId path uint true "Artifact ID" minimum(0)
@@ -181,7 +181,7 @@ func (m artifactModule) getBuildArtifactHandler(c *gin.Context) {
 // createBuildArtifactHandler godoc
 // @id createBuildArtifact
 // @summary Post build artifact
-// @description Added in TODO.
+// @description Added in v0.4.9.
 // @tags artifact
 // @accept multipart/form-data
 // @param buildId path uint true "Build ID" minimum(0)
@@ -219,7 +219,7 @@ func (m artifactModule) createBuildArtifactHandler(c *gin.Context) {
 // @deprecated
 // @summary Get build tests results from .trx files.
 // @description Deprecated, /build/{buildid}/test-result/list-summary should be used instead.
-// @description Added in TODO.
+// @description Added in v0.7.0.
 // @tags artifact
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} response.TestsResults

--- a/artifact.go
+++ b/artifact.go
@@ -45,6 +45,7 @@ var defaultGetArtifactsOrderBy = orderby.Column{Name: database.ArtifactColumns.A
 // @description List all build artifacts, or a window of build artifacts using the `limit` and `offset` query parameters. Allows optional filtering parameters.
 // @description Verbatim filters will match on the entire string used to find exact matches,
 // @description while the matching filters are meant for searches by humans where it tries to find soft matches and is therefore inaccurate by nature.
+// @description Added in TODO.
 // @tags artifact
 // @param buildId path uint true "Build ID" minimum(0)
 // @param limit query int false "Number of results to return. No limiting is applied if empty (`?limit=`) or non-positive (`?limit=0`). Required if `offset` is used." default(100)
@@ -128,6 +129,7 @@ func (m artifactModule) getBuildArtifactListHandler(c *gin.Context) {
 // getBuildArtifactHandler godoc
 // @id getBuildArtifact
 // @summary Get build artifact
+// @description Added in TODO.
 // @tags artifact
 // @param buildId path uint true "Build ID" minimum(0)
 // @param artifactId path uint true "Artifact ID" minimum(0)
@@ -179,6 +181,7 @@ func (m artifactModule) getBuildArtifactHandler(c *gin.Context) {
 // createBuildArtifactHandler godoc
 // @id createBuildArtifact
 // @summary Post build artifact
+// @description Added in TODO.
 // @tags artifact
 // @accept multipart/form-data
 // @param buildId path uint true "Build ID" minimum(0)
@@ -216,6 +219,7 @@ func (m artifactModule) createBuildArtifactHandler(c *gin.Context) {
 // @deprecated
 // @summary Get build tests results from .trx files.
 // @description Deprecated, /build/{buildid}/test-result/list-summary should be used instead.
+// @description Added in TODO.
 // @tags artifact
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} response.TestsResults

--- a/branch.go
+++ b/branch.go
@@ -29,6 +29,7 @@ func (m branchModule) Register(g *gin.RouterGroup) {
 // getProjectBranchListHandler godoc
 // @id getProjectBranchList
 // @summary Get list of branches. (NOT IMPLEMENTED!)
+// @description Added in v5.0.0.
 // @tags branch
 // @param projectId path uint true "project ID" minimum(0)
 // @success 501 "Not Implemented"
@@ -41,6 +42,7 @@ func (m branchModule) getProjectBranchListHandler(c *gin.Context) {
 // @id createProjectBranch
 // @summary Add branch to project. (NOT IMPLEMENTED!)
 // @description Adds a branch to the project, and allows you to set this new branch to be the default branch.
+// @description Added in v5.0.0.
 // @tags branch
 // @accept json
 // @produce json
@@ -58,6 +60,7 @@ func (m branchModule) createProjectBranchHandler(c *gin.Context) {
 // @description and add all branches from the request that are missing in the database.
 // @description Effectively resetting the list of branches to the list from the HTTP request body.
 // @description Useful when used via the provider APIs when importing a project.
+// @description Added in v5.0.0.
 // @tags branch
 // @accept json
 // @produce json

--- a/build.go
+++ b/build.go
@@ -87,7 +87,7 @@ func build(buildID uint) broadcast.Broadcaster {
 // getBuildHandler godoc
 // @id getBuild
 // @summary Finds build by build ID
-// @description Added in TODO.
+// @description Added in v0.3.5.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @success 200 {object} response.Build
@@ -263,7 +263,7 @@ func (m buildModule) getBuildListHandler(c *gin.Context) {
 // getBuildLogListHandler godoc
 // @id getBuildLogList
 // @summary Finds logs for build with selected build ID
-// @description Added in TODO.
+// @description Added in v0.3.8.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @success 200 {object} []response.Log "logs from selected build"
@@ -301,7 +301,7 @@ func (m buildModule) getBuildLogListHandler(c *gin.Context) {
 // streamBuildLogHandler godoc
 // @id streamBuildLog
 // @summary Opens stream listener
-// @description Added in TODO.
+// @description Added in v0.3.8.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @success 200 "Open stream"
@@ -332,7 +332,7 @@ func (m buildModule) streamBuildLogHandler(c *gin.Context) {
 // createBuildLogHandler godoc
 // @id createBuildLog
 // @summary Post a log to selected build
-// @description Added in TODO.
+// @description Added in v0.1.0.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @param data body request.LogOrStatusUpdate true "data"

--- a/build.go
+++ b/build.go
@@ -471,6 +471,7 @@ func (m buildModule) getLogs(buildID uint) ([]database.Log, error) {
 // @summary Responsible for run stage environment for selected project
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `POST /project/{projectId}/build` instead.
+// @description Added in v0.2.4.
 // @tags project
 // @accept json
 // @param projectId path uint true "project ID" minimum(0)

--- a/build.go
+++ b/build.go
@@ -87,6 +87,7 @@ func build(buildID uint) broadcast.Broadcaster {
 // getBuildHandler godoc
 // @id getBuild
 // @summary Finds build by build ID
+// @description Added in TODO.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @success 200 {object} response.Build
@@ -137,6 +138,7 @@ var defaultGetBuildsOrderBy = orderby.Column{Name: database.BuildColumns.BuildID
 // @description List all builds, or a window of builds using the `limit` and `offset` query parameters. Allows optional filtering parameters.
 // @description Verbatim filters will match on the entire string used to find exact matches,
 // @description while the matching filters are meant for searches by humans where it tries to find soft matches and is therefore inaccurate by nature.
+// @description Added in v5.0.0.
 // @tags build
 // @param limit query int false "Number of results to return. No limiting is applied if empty (`?limit=`) or non-positive (`?limit=0`). Required if `offset` is used." default(100)
 // @param offset query int false "Skipped results, where 0 means from the start." minimum(0) default(0)
@@ -261,6 +263,7 @@ func (m buildModule) getBuildListHandler(c *gin.Context) {
 // getBuildLogListHandler godoc
 // @id getBuildLogList
 // @summary Finds logs for build with selected build ID
+// @description Added in TODO.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @success 200 {object} []response.Log "logs from selected build"
@@ -298,6 +301,7 @@ func (m buildModule) getBuildLogListHandler(c *gin.Context) {
 // streamBuildLogHandler godoc
 // @id streamBuildLog
 // @summary Opens stream listener
+// @description Added in TODO.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @success 200 "Open stream"
@@ -328,6 +332,7 @@ func (m buildModule) streamBuildLogHandler(c *gin.Context) {
 // createBuildLogHandler godoc
 // @id createBuildLog
 // @summary Post a log to selected build
+// @description Added in TODO.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @param data body request.LogOrStatusUpdate true "data"
@@ -380,6 +385,7 @@ func (m buildModule) createBuildLogHandler(c *gin.Context) {
 // updateBuildStatusHandler godoc
 // @id updateBuildStatus
 // @summary Update a build's status. (NOT IMPLEMENTED!)
+// @description Added in v5.0.0.
 // @tags build
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 501 "Not Implemented"
@@ -499,6 +505,7 @@ func (m buildModule) oldStartProjectBuildHandler(c *gin.Context) {
 // startProjectBuildHandler godoc
 // @id startProjectBuild
 // @summary Start a new build for the given project, with optional build stage, build environment, or repo branch filters.
+// @description Added in v5.0.0.
 // @tags build
 // @accept json
 // @param projectId path uint true "Project ID" minimum(0)

--- a/internal/deprecated/artifact.go
+++ b/internal/deprecated/artifact.go
@@ -28,7 +28,7 @@ func (m artifactModule) Register(g *gin.RouterGroup) {
 // @summary Get list of build artifacts
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /build/{buildId}/artifact` instead.
-// @description Added in TODO.
+// @description Added in v0.4.9.
 // @tags artifact
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} []response.Artifact

--- a/internal/deprecated/artifact.go
+++ b/internal/deprecated/artifact.go
@@ -28,6 +28,7 @@ func (m artifactModule) Register(g *gin.RouterGroup) {
 // @summary Get list of build artifacts
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /build/{buildId}/artifact` instead.
+// @description Added in TODO.
 // @tags artifact
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} []response.Artifact

--- a/internal/deprecated/branch.go
+++ b/internal/deprecated/branch.go
@@ -38,6 +38,7 @@ func (m BranchModule) Register(g *gin.RouterGroup) {
 // @summary Get a branch by ID
 // @description This endpoint has not been implemented!
 // @description Deprecated since v4.3.0. Planned for removal in v6.0.0.
+// @description Added in TODO.
 // @tags branch
 // @param branchId path uint true "branch ID" minimum(0)
 // @success 501 "Not Implemented"
@@ -52,6 +53,7 @@ func (m BranchModule) GetBranchHandler(c *gin.Context) {
 // @description This endpoint was never implemented!
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /project/{projectId}/branch` instead.
+// @description Added in TODO.
 // @summary NOT IMPLEMENTED
 // @tags branch
 // @success 501 "Not Implemented"
@@ -78,6 +80,7 @@ type Branch struct {
 // @description If not existing new branch will be created.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `PUT /project/{projectId}/branch` instead.
+// @description Added in TODO.
 // @tags branch
 // @accept json
 // @produce json
@@ -136,6 +139,7 @@ func (m BranchModule) createBranchHandler(c *gin.Context) {
 // @description Alters the database by removing, adding and updating until the stored branches equals the input branches.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use PUT /project/{projectId}/branch instead.
+// @description Added in TODO.
 // @tags branches
 // @accept json
 // @produce json

--- a/internal/deprecated/branch.go
+++ b/internal/deprecated/branch.go
@@ -38,7 +38,7 @@ func (m BranchModule) Register(g *gin.RouterGroup) {
 // @summary Get a branch by ID
 // @description This endpoint has not been implemented!
 // @description Deprecated since v4.3.0. Planned for removal in v6.0.0.
-// @description Added in TODO.
+// @description Added in v0.2.0.
 // @tags branch
 // @param branchId path uint true "branch ID" minimum(0)
 // @success 501 "Not Implemented"
@@ -53,7 +53,7 @@ func (m BranchModule) GetBranchHandler(c *gin.Context) {
 // @description This endpoint was never implemented!
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /project/{projectId}/branch` instead.
-// @description Added in TODO.
+// @description Added in v0.2.0.
 // @summary NOT IMPLEMENTED
 // @tags branch
 // @success 501 "Not Implemented"
@@ -80,7 +80,7 @@ type Branch struct {
 // @description If not existing new branch will be created.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `PUT /project/{projectId}/branch` instead.
-// @description Added in TODO.
+// @description Added in v0.2.0.
 // @tags branch
 // @accept json
 // @produce json
@@ -139,7 +139,7 @@ func (m BranchModule) createBranchHandler(c *gin.Context) {
 // @description Alters the database by removing, adding and updating until the stored branches equals the input branches.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use PUT /project/{projectId}/branch instead.
-// @description Added in TODO.
+// @description Added in v1.0.0.
 // @tags branches
 // @accept json
 // @produce json

--- a/internal/deprecated/build.go
+++ b/internal/deprecated/build.go
@@ -43,6 +43,7 @@ func (m BuildModule) Register(g *gin.RouterGroup) {
 // @description This endpoint was never implemented!
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /build` instead.
+// @description Added in TODO.
 // @summary NOT IMPLEMENTED YET
 // @tags build
 // @accept json
@@ -59,6 +60,7 @@ func (m BuildModule) searchBuildListHandler(c *gin.Context) {
 // @summary Partially update specific build
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `PUT /build/{buildId}/status` instead.
+// @description Added in TODO.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @param status query string true "Build status term" Enums(Scheduling, Running, Completed, Failed)

--- a/internal/deprecated/build.go
+++ b/internal/deprecated/build.go
@@ -43,7 +43,7 @@ func (m BuildModule) Register(g *gin.RouterGroup) {
 // @description This endpoint was never implemented!
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /build` instead.
-// @description Added in TODO.
+// @description Added in v0.3.5.
 // @summary NOT IMPLEMENTED YET
 // @tags build
 // @accept json
@@ -60,7 +60,7 @@ func (m BuildModule) searchBuildListHandler(c *gin.Context) {
 // @summary Partially update specific build
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `PUT /build/{buildId}/status` instead.
-// @description Added in TODO.
+// @description Added in v2.0.1.
 // @tags build
 // @param buildId path uint true "build id" minimum(0)
 // @param status query string true "Build status term" Enums(Scheduling, Running, Completed, Failed)

--- a/internal/deprecated/project.go
+++ b/internal/deprecated/project.go
@@ -71,6 +71,7 @@ func (m ProjectModule) Register(g *gin.RouterGroup) {
 // @summary Returns all projects from database
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /project` instead.
+// @description Added in v0.1.8.
 // @tags project
 // @success 200 {object} []response.Project
 // @failure 502 {object} problem.Response "Database is unreachable"
@@ -95,6 +96,7 @@ func (m ProjectModule) getProjectListHandler(c *gin.Context) {
 // @summary Search for projects from database
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /project` instead.
+// @description Added in v0.5.5.
 // @tags project
 // @param project body ProjectSearch _ "Project search criteria"
 // @success 200 {object} []response.Project
@@ -148,6 +150,7 @@ var buildJSONToColumns = map[string]database.SafeSQLName{
 // @summary Get slice of builds.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /build?projectId=123` instead.
+// @description Added in v1.0.1.
 // @tags project
 // @param projectId path uint true "project ID" minimum(0)
 // @param limit query string true "number of fetched branches"
@@ -214,6 +217,7 @@ func (m ProjectModule) getProjectBuildListHandler(c *gin.Context) {
 // @description It ignores branches array, build history and provider params.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use POST /project to create, or PUT /project/{projectId} to update instead.
+// @description Added in v0.2.13.
 // @tags project
 // @accept json
 // @produce json

--- a/internal/deprecated/provider.go
+++ b/internal/deprecated/provider.go
@@ -48,6 +48,7 @@ func (m ProviderModule) Register(g *gin.RouterGroup) {
 // @summary Returns first 100 providers
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /provider` instead.
+// @description Added in TODO.
 // @tags provider
 // @success 200 {object} []response.Provider
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
@@ -72,6 +73,7 @@ func (m ProviderModule) getProviderListHandler(c *gin.Context) {
 // @description It takes into consideration name, URL and token ID.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /provider` instead.
+// @description Added in TODO.
 // @tags provider
 // @accept json
 // @produce json
@@ -143,6 +145,7 @@ func (m ProviderModule) searchProviderListHandler(c *gin.Context) {
 // @description Creates a new provider if a match is not found.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use POST /provider to create, or PUT /provider/{providerId} to update instead.
+// @description Added in TODO.
 // @tags provider
 // @accept json
 // @produce json

--- a/internal/deprecated/provider.go
+++ b/internal/deprecated/provider.go
@@ -48,7 +48,7 @@ func (m ProviderModule) Register(g *gin.RouterGroup) {
 // @summary Returns first 100 providers
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /provider` instead.
-// @description Added in TODO.
+// @description Added in v0.3.9.
 // @tags provider
 // @success 200 {object} []response.Provider
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
@@ -73,7 +73,7 @@ func (m ProviderModule) getProviderListHandler(c *gin.Context) {
 // @description It takes into consideration name, URL and token ID.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /provider` instead.
-// @description Added in TODO.
+// @description Added in v0.3.9.
 // @tags provider
 // @accept json
 // @produce json
@@ -145,7 +145,7 @@ func (m ProviderModule) searchProviderListHandler(c *gin.Context) {
 // @description Creates a new provider if a match is not found.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use POST /provider to create, or PUT /provider/{providerId} to update instead.
-// @description Added in TODO.
+// @description Added in v4.1.0.
 // @tags provider
 // @accept json
 // @produce json

--- a/internal/deprecated/token.go
+++ b/internal/deprecated/token.go
@@ -47,6 +47,7 @@ func (m TokenModule) Register(g *gin.RouterGroup) {
 // @summary Returns first 100 tokens
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /token` instead.
+// @description Added in TODO.
 // @tags token
 // @success 200 {object} []response.Token
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
@@ -72,6 +73,7 @@ func (m TokenModule) getTokenListHandler(c *gin.Context) {
 // @description It takes into consideration only token string and user name.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /token` instead.
+// @description Added in TODO.
 // @tags token
 // @accept json
 // @produce json
@@ -115,6 +117,7 @@ func (m TokenModule) searchTokenListHandler(c *gin.Context) {
 // @description Creates a new token if a match is not found.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use POST /token to create, or PUT /token/{tokenId} to update instead.
+// @description Added in TODO.
 // @tags token
 // @accept json
 // @produce json

--- a/internal/deprecated/token.go
+++ b/internal/deprecated/token.go
@@ -47,7 +47,7 @@ func (m TokenModule) Register(g *gin.RouterGroup) {
 // @summary Returns first 100 tokens
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /token` instead.
-// @description Added in TODO.
+// @description Added in v0.2.0.
 // @tags token
 // @success 200 {object} []response.Token
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
@@ -73,7 +73,7 @@ func (m TokenModule) getTokenListHandler(c *gin.Context) {
 // @description It takes into consideration only token string and user name.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use `GET /token` instead.
-// @description Added in TODO.
+// @description Added in v0.2.10.
 // @tags token
 // @accept json
 // @produce json
@@ -117,7 +117,7 @@ func (m TokenModule) searchTokenListHandler(c *gin.Context) {
 // @description Creates a new token if a match is not found.
 // @description Deprecated since v5.0.0. Planned for removal in v6.0.0.
 // @description Use POST /token to create, or PUT /token/{tokenId} to update instead.
-// @description Added in TODO.
+// @description Added in v4.1.0.
 // @tags token
 // @accept json
 // @produce json

--- a/ping.go
+++ b/ping.go
@@ -17,15 +17,15 @@ func (m healthModule) Register(g *gin.RouterGroup) {
 // Deprecated: Not part of the /api group for endpoints. Tentatively planned
 // for complete removal in v6.
 func (m healthModule) DeprecatedRegister(e *gin.Engine) {
-	e.GET("/", m.pingHandler)
-	e.GET("/health", m.healthHandler)
+	e.GET("/", m.pingHandler)         // added in v0.1.8
+	e.GET("/health", m.healthHandler) // added in v0.7.1
 }
 
 // pingHandler godoc
 // @id pingHandler
 // @summary Ping
 // @description You guessed it. Pong.
-// @description Added in TODO.
+// @description Added in v4.2.0.
 // @tags health
 // @produce json
 // @success 200 {object} response.Ping
@@ -38,7 +38,7 @@ func (m healthModule) pingHandler(c *gin.Context) {
 // @id getHealth
 // @summary Healthcheck for the API
 // @description To be used by Kubernetes or alike.
-// @description Added in TODO.
+// @description Added in v0.7.1.
 // @tags health
 // @produce json
 // @success 200 {object} response.HealthStatus

--- a/ping.go
+++ b/ping.go
@@ -25,6 +25,7 @@ func (m healthModule) DeprecatedRegister(e *gin.Engine) {
 // @id pingHandler
 // @summary Ping
 // @description You guessed it. Pong.
+// @description Added in TODO.
 // @tags health
 // @produce json
 // @success 200 {object} response.Ping
@@ -37,6 +38,7 @@ func (m healthModule) pingHandler(c *gin.Context) {
 // @id getHealth
 // @summary Healthcheck for the API
 // @description To be used by Kubernetes or alike.
+// @description Added in TODO.
 // @tags health
 // @produce json
 // @success 200 {object} response.HealthStatus

--- a/project.go
+++ b/project.go
@@ -61,6 +61,7 @@ var defaultGetProjectsOrderBy = orderby.Column{Name: database.ProjectColumns.Pro
 // @description List all projects, or a window of projects using the `limit` and `offset` query parameters. Allows optional filtering parameters.
 // @description Verbatim filters will match on the entire string used to find exact matches,
 // @description while the matching filters are meant for searches by humans where it tries to find soft matches and is therefore inaccurate by nature.
+// @description Added in v5.0.0.
 // @tags project
 // @param orderby query []string false "Sorting orders. Takes the property name followed by either 'asc' or 'desc'. Can be specified multiple times for more granular sorting. Defaults to `?orderby=projectId desc`"
 // @param limit query int false "Number of results to return. No limiting is applied if empty (`?limit=`) or non-positive (`?limit=0`). Required if `offset` is used." default(100)
@@ -151,6 +152,7 @@ func (m projectModule) getProjectListHandler(c *gin.Context) {
 // getProjectHandler godoc
 // @id getProject
 // @summary Returns project with selected project ID
+// @description Added in v0.1.8.
 // @tags project
 // @param projectId path uint true "project ID" minimum(0)
 // @success 200 {object} response.Project
@@ -176,6 +178,7 @@ func (m projectModule) getProjectHandler(c *gin.Context) {
 // @id createProject
 // @summary Creates project
 // @description Add project to database.
+// @description Added in v0.1.10.
 // @tags project
 // @accept json
 // @produce json
@@ -209,6 +212,7 @@ func (m projectModule) createProjectHandler(c *gin.Context) {
 // deleteProjectHandler godoc
 // @id deleteProject
 // @summary Delete project with selected project ID
+// @description Added in v0.2.8.
 // @tags project
 // @param projectId path uint true "project ID" minimum(0)
 // @success 204 "Deleted"
@@ -238,6 +242,7 @@ func (m projectModule) deleteProjectHandler(c *gin.Context) {
 // @id updateProject
 // @summary Update project in database
 // @description Updates a project by replacing all of its fields.
+// @description Added in v5.0.0.
 // @tags project
 // @accept json
 // @produce json

--- a/project.go
+++ b/project.go
@@ -297,6 +297,7 @@ func (m projectModule) updateProjectHandler(c *gin.Context) {
 // @description Meant for manual overrides.
 // @description Overridden field will take precedence when retreiving the project or in newly started builds,
 // @description but will stay unaffected by regular project updates.
+// @description Added in TODO.
 // @tags project
 // @produce json
 // @param projectId path uint true "project ID" minimum(0)
@@ -339,6 +340,7 @@ func (m projectModule) getProjectOverridesHandler(c *gin.Context) {
 // @description Meant for manual overrides.
 // @description Overridden field will take precedence when retreiving the project or in newly started builds,
 // @description but will stay unaffected by regular project updates.
+// @description Added in TODO.
 // @tags project
 // @accept json
 // @produce json
@@ -395,6 +397,7 @@ func (m projectModule) updateProjectOverridesHandler(c *gin.Context) {
 // @summary Delete project's overrides with selected project ID
 // @description This will revert all overrides to the specified project.
 // @description Equivalent to running `PUT /project/{projectId}/overrides` with all fields set to `null`.
+// @description Added in TODO.
 // @tags project
 // @param projectId path uint true "project ID" minimum(0)
 // @success 204 "Deleted"

--- a/project.go
+++ b/project.go
@@ -297,7 +297,7 @@ func (m projectModule) updateProjectHandler(c *gin.Context) {
 // @description Meant for manual overrides.
 // @description Overridden field will take precedence when retreiving the project or in newly started builds,
 // @description but will stay unaffected by regular project updates.
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags project
 // @produce json
 // @param projectId path uint true "project ID" minimum(0)
@@ -340,7 +340,7 @@ func (m projectModule) getProjectOverridesHandler(c *gin.Context) {
 // @description Meant for manual overrides.
 // @description Overridden field will take precedence when retreiving the project or in newly started builds,
 // @description but will stay unaffected by regular project updates.
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags project
 // @accept json
 // @produce json
@@ -397,7 +397,7 @@ func (m projectModule) updateProjectOverridesHandler(c *gin.Context) {
 // @summary Delete project's overrides with selected project ID
 // @description This will revert all overrides to the specified project.
 // @description Equivalent to running `PUT /project/{projectId}/overrides` with all fields set to `null`.
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags project
 // @param projectId path uint true "project ID" minimum(0)
 // @success 204 "Deleted"

--- a/provider.go
+++ b/provider.go
@@ -49,6 +49,7 @@ var defaultGetProvidersOrderBy = orderby.Column{Name: database.ProviderColumns.P
 // @description List all providers, or a window of providers using the `limit` and `offset` query parameters. Allows optional filtering parameters.
 // @description Verbatim filters will match on the entire string used to find exact matches,
 // @description while the matching filters are meant for searches by humans where it tries to find soft matches and is therefore inaccurate by nature.
+// @description Added in TODO.
 // @tags provider
 // @param limit query int false "Number of results to return. No limiting is applied if empty (`?limit=`) or non-positive (`?limit=0`). Required if `offset` is used." default(100)
 // @param offset query int false "Skipped results, where 0 means from the start." minimum(0) default(0)
@@ -121,6 +122,7 @@ func (m providerModule) getProviderListHandler(c *gin.Context) {
 // getProviderHandler godoc
 // @id getProvider
 // @summary Returns provider with selected provider ID
+// @description Added in TODO.
 // @tags provider
 // @param providerId path uint true "Provider ID" minimum(0)
 // @success 200 {object} response.Provider
@@ -149,6 +151,7 @@ func (m providerModule) getProviderHandler(c *gin.Context) {
 // @summary Add provider to database.
 // @description Add provider to database. Token in post object has to exists or should be empty.
 // @description Token will has to be updated Provider ID during this operation.
+// @description Added in TODO.
 // @tags provider
 // @accept json
 // @produce json
@@ -193,6 +196,7 @@ func (m providerModule) createProviderHandler(c *gin.Context) {
 // @id updateProvider
 // @summary Update provider in database.
 // @description Updates a provider by replacing all of its fields.
+// @description Added in TODO.
 // @tags provider
 // @accept json
 // @produce json

--- a/provider.go
+++ b/provider.go
@@ -49,7 +49,7 @@ var defaultGetProvidersOrderBy = orderby.Column{Name: database.ProviderColumns.P
 // @description List all providers, or a window of providers using the `limit` and `offset` query parameters. Allows optional filtering parameters.
 // @description Verbatim filters will match on the entire string used to find exact matches,
 // @description while the matching filters are meant for searches by humans where it tries to find soft matches and is therefore inaccurate by nature.
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags provider
 // @param limit query int false "Number of results to return. No limiting is applied if empty (`?limit=`) or non-positive (`?limit=0`). Required if `offset` is used." default(100)
 // @param offset query int false "Skipped results, where 0 means from the start." minimum(0) default(0)
@@ -122,7 +122,7 @@ func (m providerModule) getProviderListHandler(c *gin.Context) {
 // getProviderHandler godoc
 // @id getProvider
 // @summary Returns provider with selected provider ID
-// @description Added in TODO.
+// @description Added in v0.3.9.
 // @tags provider
 // @param providerId path uint true "Provider ID" minimum(0)
 // @success 200 {object} response.Provider
@@ -151,7 +151,7 @@ func (m providerModule) getProviderHandler(c *gin.Context) {
 // @summary Add provider to database.
 // @description Add provider to database. Token in post object has to exists or should be empty.
 // @description Token will has to be updated Provider ID during this operation.
-// @description Added in TODO.
+// @description Added in v0.3.9.
 // @tags provider
 // @accept json
 // @produce json
@@ -196,7 +196,7 @@ func (m providerModule) createProviderHandler(c *gin.Context) {
 // @id updateProvider
 // @summary Update provider in database.
 // @description Updates a provider by replacing all of its fields.
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags provider
 // @accept json
 // @produce json

--- a/test_result.go
+++ b/test_result.go
@@ -38,7 +38,7 @@ func (m buildTestResultModule) Register(r gin.IRouter) {
 // createBuildTestResultHandler godoc
 // @id createBuildTestResult
 // @summary Post test result data
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags test-result
 // @accept multipart/form-data
 // @param buildId path uint true "Build ID" minimum(0)
@@ -126,7 +126,7 @@ func (m buildTestResultModule) createBuildTestResultHandler(c *gin.Context) {
 // getBuildAllTestResultDetailListHandler godoc
 // @id getBuildAllTestResultDetailList
 // @summary Get all test result details for specified build
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} response.PaginatedTestResultDetails
@@ -162,7 +162,7 @@ func (m buildTestResultModule) getBuildAllTestResultDetailListHandler(c *gin.Con
 // getBuildAllTestResultSummaryListHandler godoc
 // @id getBuildAllTestResultSummaryList
 // @summary Get all test result summaries for specified build
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} response.PaginatedTestResultSummaries
@@ -202,7 +202,7 @@ func (m buildTestResultModule) getBuildAllTestResultSummaryListHandler(c *gin.Co
 // getBuildTestResultSummaryHandler godoc
 // @id getBuildTestResultSummary
 // @summary Get test result summary for specified test
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @param artifactId path uint true "Artifact ID" minimum(0)
@@ -241,7 +241,7 @@ func (m buildTestResultModule) getBuildTestResultSummaryHandler(c *gin.Context) 
 // getBuildTestResultDetailListHandler godoc
 // @id getBuildTestResultDetailList
 // @summary Get all test result details for specified test
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @param artifactId path uint true "Artifact ID" minimum(0)
@@ -283,7 +283,7 @@ func (m buildTestResultModule) getBuildTestResultDetailListHandler(c *gin.Contex
 // getBuildAllTestResultListSummaryHandler godoc
 // @id getBuildAllTestResultListSummary
 // @summary Get test result list summary of all tests for specified build
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} response.TestResultListSummary

--- a/test_result.go
+++ b/test_result.go
@@ -38,6 +38,7 @@ func (m buildTestResultModule) Register(r gin.IRouter) {
 // createBuildTestResultHandler godoc
 // @id createBuildTestResult
 // @summary Post test result data
+// @description Added in TODO.
 // @tags test-result
 // @accept multipart/form-data
 // @param buildId path uint true "Build ID" minimum(0)
@@ -125,6 +126,7 @@ func (m buildTestResultModule) createBuildTestResultHandler(c *gin.Context) {
 // getBuildAllTestResultDetailListHandler godoc
 // @id getBuildAllTestResultDetailList
 // @summary Get all test result details for specified build
+// @description Added in TODO.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} response.PaginatedTestResultDetails
@@ -160,6 +162,7 @@ func (m buildTestResultModule) getBuildAllTestResultDetailListHandler(c *gin.Con
 // getBuildAllTestResultSummaryListHandler godoc
 // @id getBuildAllTestResultSummaryList
 // @summary Get all test result summaries for specified build
+// @description Added in TODO.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} response.PaginatedTestResultSummaries
@@ -199,6 +202,7 @@ func (m buildTestResultModule) getBuildAllTestResultSummaryListHandler(c *gin.Co
 // getBuildTestResultSummaryHandler godoc
 // @id getBuildTestResultSummary
 // @summary Get test result summary for specified test
+// @description Added in TODO.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @param artifactId path uint true "Artifact ID" minimum(0)
@@ -237,6 +241,7 @@ func (m buildTestResultModule) getBuildTestResultSummaryHandler(c *gin.Context) 
 // getBuildTestResultDetailListHandler godoc
 // @id getBuildTestResultDetailList
 // @summary Get all test result details for specified test
+// @description Added in TODO.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @param artifactId path uint true "Artifact ID" minimum(0)
@@ -278,6 +283,7 @@ func (m buildTestResultModule) getBuildTestResultDetailListHandler(c *gin.Contex
 // getBuildAllTestResultListSummaryHandler godoc
 // @id getBuildAllTestResultListSummary
 // @summary Get test result list summary of all tests for specified build
+// @description Added in TODO.
 // @tags test-result
 // @param buildId path uint true "Build ID" minimum(0)
 // @success 200 {object} response.TestResultListSummary

--- a/token.go
+++ b/token.go
@@ -49,7 +49,7 @@ var defaultGetTokensOrderBy = orderby.Column{Name: database.TokenColumns.TokenID
 // @description List all tokens, or a window of tokens using the `limit` and `offset` query parameters. Allows optional filtering parameters.
 // @description Verbatim filters will match on the entire string used to find exact matches,
 // @description while the matching filters are meant for searches by humans where it tries to find soft matches and is therefore inaccurate by nature.
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags token
 // @param limit query int false "Number of results to return. No limiting is applied if empty (`?limit=`) or non-positive (`?limit=0`). Required if `offset` is used." default(100)
 // @param offset query int false "Skipped results, where 0 means from the start." minimum(0) default(0)
@@ -107,7 +107,7 @@ func (m tokenModule) getTokenListHandler(c *gin.Context) {
 // getTokenHandler godoc
 // @id getToken
 // @summary Returns token with selected token ID
-// @description Added in TODO.
+// @description Added in v0.2.2.
 // @tags token
 // @param tokenId path uint true "Token ID" minimum(0)
 // @success 200 {object} response.Token
@@ -134,7 +134,7 @@ func (m tokenModule) getTokenHandler(c *gin.Context) {
 // @id createToken
 // @summary Add token to database.
 // @description Add token to database. Provider in post object has to exists or should be empty.
-// @description Added in TODO.
+// @description Added in v0.2.0.
 // @tags token
 // @accept json
 // @produce json
@@ -185,7 +185,7 @@ func (m tokenModule) createTokenHandler(c *gin.Context) {
 // @id updateToken
 // @summary Update token in database.
 // @description Updates a token by replacing all of its fields.
-// @description Added in TODO.
+// @description Added in v5.0.0.
 // @tags token
 // @accept json
 // @produce json

--- a/token.go
+++ b/token.go
@@ -49,6 +49,7 @@ var defaultGetTokensOrderBy = orderby.Column{Name: database.TokenColumns.TokenID
 // @description List all tokens, or a window of tokens using the `limit` and `offset` query parameters. Allows optional filtering parameters.
 // @description Verbatim filters will match on the entire string used to find exact matches,
 // @description while the matching filters are meant for searches by humans where it tries to find soft matches and is therefore inaccurate by nature.
+// @description Added in TODO.
 // @tags token
 // @param limit query int false "Number of results to return. No limiting is applied if empty (`?limit=`) or non-positive (`?limit=0`). Required if `offset` is used." default(100)
 // @param offset query int false "Skipped results, where 0 means from the start." minimum(0) default(0)
@@ -106,6 +107,7 @@ func (m tokenModule) getTokenListHandler(c *gin.Context) {
 // getTokenHandler godoc
 // @id getToken
 // @summary Returns token with selected token ID
+// @description Added in TODO.
 // @tags token
 // @param tokenId path uint true "Token ID" minimum(0)
 // @success 200 {object} response.Token
@@ -132,6 +134,7 @@ func (m tokenModule) getTokenHandler(c *gin.Context) {
 // @id createToken
 // @summary Add token to database.
 // @description Add token to database. Provider in post object has to exists or should be empty.
+// @description Added in TODO.
 // @tags token
 // @accept json
 // @produce json
@@ -182,6 +185,7 @@ func (m tokenModule) createTokenHandler(c *gin.Context) {
 // @id updateToken
 // @summary Update token in database.
 // @description Updates a token by replacing all of its fields.
+// @description Added in TODO.
 // @tags token
 // @accept json
 // @produce json

--- a/version.go
+++ b/version.go
@@ -24,7 +24,7 @@ func loadEmbeddedVersionFile() error {
 // getVersionHandler godoc
 // @id getVersion
 // @summary Returns the version of this API
-// @description Added in TODO.
+// @description Added in v4.0.0.
 // @tags meta
 // @success 200 {object} app.Version
 // @router /version [get]

--- a/version.go
+++ b/version.go
@@ -24,6 +24,7 @@ func loadEmbeddedVersionFile() error {
 // getVersionHandler godoc
 // @id getVersion
 // @summary Returns the version of this API
+// @description Added in TODO.
 // @tags meta
 // @success 200 {object} app.Version
 // @router /version [get]


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `@description Added in x.y.z.` to all endpoints.

## Motivation

Just documenting all endpoints to have more ways to detect when an endpoint was added.

Took some time to dig these versions up from our old archived repos. Luckily in the early days of Wharf it was just 1 repo and the author pushed directly to master, so those parts were easy to track down :]


