### PR TITLE
Fixed GET /project using providerJSONToColumns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Deprecated POST search endpoints that took the search queries from the HTTP
   request body. They are still supported, but may be removed in the next major
   release (v6.0.0). Please refer to the new endpoints that use query parameter
-  instead. (#99, #109)
+  instead. (#99, #109, #123)
 
   - Use new `GET /project` instead of `GET /projects` or `POST /projects/search`
   - Use new `GET /build` instead of `GET /projects/{projectId}/builds` or `POST /builds/search`

--- a/project.go
+++ b/project.go
@@ -103,7 +103,7 @@ func (m projectModule) getProjectListHandler(c *gin.Context) {
 	if !bindCommonGetQueryParams(c, &params) {
 		return
 	}
-	orderBySlice, ok := parseCommonOrderBySlice(c, params.OrderBy, providerJSONToColumns)
+	orderBySlice, ok := parseCommonOrderBySlice(c, params.OrderBy, projectJSONToColumns)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed `GET /project` using `providerJSONToColumns` instead of `projectJSONToColumns`

## Motivation

Copy-paste typo in #109 at https://github.com/iver-wharf/wharf-api/pull/109/files#diff-5bd45f0b550e390a3e0aa2ce718715f311ca88105ce8bfce2e1c32c234bda60eL110-R108

Noted by @Alexamakans in: <https://github.com/iver-wharf/wharf-api/commit/dd0f4c593b81bd5b9f80d08d4ad5b7f2ada036e8#r60557365>
