### PR TITLE
Changed .wharf-ci.yml for canary builds

### DIFF
--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -7,3 +7,4 @@ build:
         - BUILD_VERSION=${GIT_BRANCH}
         - BUILD_GIT_COMMIT=${GIT_COMMIT}
         - BUILD_REF=${BUILD_REF}
+        - REG=${REG_URL}/hub

--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -2,7 +2,7 @@ build:
   wharf-api:
     docker:
       file: Dockerfile
-      tag: unstable
+      tag: canary
       args:
         - BUILD_VERSION=${GIT_BRANCH}
         - BUILD_GIT_COMMIT=${GIT_COMMIT}

--- a/.wharf-ci.yml
+++ b/.wharf-ci.yml
@@ -1,10 +1,9 @@
 build:
-  api:
+  wharf-api:
     docker:
       file: Dockerfile
-      tag: ${GIT_COMMIT},${GIT_TAG},latest
-      append-cert: false
+      tag: unstable
       args:
-        - BUILD_VERSION=${GIT_TAG}
+        - BUILD_VERSION=${GIT_BRANCH}
         - BUILD_GIT_COMMIT=${GIT_COMMIT}
         - BUILD_REF=${BUILD_REF}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.16 AS build
+ARG REG=docker.io
+FROM ${REG}/library/golang:1.16 AS build
 WORKDIR /src
 RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.1
 COPY go.mod go.sum ./
@@ -14,7 +15,8 @@ RUN deploy/update-version.sh version.yaml \
 		&& CGO_ENABLED=0 go build -o main \
 		&& make test
 
-FROM alpine:3.14 AS final
+ARG REG=docker.io
+FROM ${REG}/library/alpine:3.14 AS final
 RUN apk add --no-cache ca-certificates tzdata
 WORKDIR /app
 COPY --from=build /src/main ./


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed deploy tag in `.wharf-ci.yml` to `:canary`
- Changed to use our internal Docker Hub registry caching proxy in Docker builds
- Fixed Wharf build step name in `.wharf-ci.yml`

## Motivation

Minor tweaks to make the Wharf builds work and be able to build Wharf itself.

~~The image tag name `:unstable` is up for debate. Perhaps `:canary`? Or simply `:latest`?~~ Changed to `:canary`.

Related to https://github.com/iver-wharf/iver-wharf.github.io/issues/80

This is the first PR I'm marking "Ready for review". Let's have all discussions in this PR to begin with, as the other PRs listed in the meta-issue above are basically just the same.