### PR TITLE
Fixed foreign key constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,7 +213,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Added endpoints to allow setting manual overrides for a project. These
   overrides are used in responses from `GET /project` and other, as well as in
-  build parameters for newly started builds. New endpoints: (#117)
+  build parameters for newly started builds. New endpoints: (#117, #127)
 
   - `GET /project/{projectId}/override` to get all overrides
   - `PUT /project/{projectId}/override` to set all overrides

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -193,13 +193,13 @@ type Project struct {
 	Branches        []Branch  `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	GitURL          string    `gorm:"not null;default:''"`
 
-	Overrides ProjectOverrides `gorm:"foreignKey:ProjectID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Overrides ProjectOverrides `gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 }
 
 // ProjectOverrides holds data about a project's overridden values.
 type ProjectOverrides struct {
 	ProjectOverridesID uint   `gorm:"primaryKey"`
-	ProjectID          uint   `gorm:"uniqueIndex:project_overrides_idx_project_id"`
+	ProjectID          uint   `gorm:"foreignKey:ProjectID;uniqueIndex:project_overrides_idx_project_id"`
 	Description        string `gorm:"size:500;not null;default:''"`
 	AvatarURL          string `gorm:"size:500;not null;default:''"`
 	GitURL             string `gorm:"not null;default:''"`


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Moved GORM foreignKey tag from `Project.Overrides` to `ProjectOverrides.ProjectID`.

## Motivation

Fixes inability to insert projects into the database when using postgresql.