### PR TITLE
Release v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v5.0.0 (WIP)
+## v5.0.0 (2022-01-13)
 
 - BREAKING: Changed module path from `github.com/iver-wharf/wharf-api` to
   `github.com/iver-wharf/wharf-api/v5`. (#128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v5.0.0 (2022-01-14)
+## v5.0.0 (2022-01-17)
 
 - BREAKING: Changed module path from `github.com/iver-wharf/wharf-api` to
   `github.com/iver-wharf/wharf-api/v5`. (#128)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v5.0.0 (2022-01-13)
+## v5.0.0 (2022-01-14)
 
 - BREAKING: Changed module path from `github.com/iver-wharf/wharf-api` to
   `github.com/iver-wharf/wharf-api/v5`. (#128)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

Big update! Now includes implementation for the following RFCs:

- [RFC-0013: authentication & authorization](https://iver-wharf.github.io/rfcs/published/0013-authentication) (https://github.com/iver-wharf/rfcs/pull/13)
- [RFC-0014: rework-handling-of-test-results](https://iver-wharf.github.io/rfcs/published/0014-test-results-handling) (https://github.com/iver-wharf/rfcs/pull/14)
- [RFC-0016: wharf-api-endpoints-cleanup](https://iver-wharf.github.io/rfcs/published/0016-wharf-api-endpoints-cleanup) (https://github.com/iver-wharf/rfcs/pull/16)
- [RFC-0024: Project overrides](https://iver-wharf.github.io/rfcs/published/0024-project-overrides) (https://github.com/iver-wharf/rfcs/pull/24)
- [RFC-0026: v2+ Go modules release](https://iver-wharf.github.io/rfcs/published/0026-v2-go-modules-release) (https://github.com/iver-wharf/rfcs/pull/26)

## Changes

- BREAKING: Changed module path from `github.com/iver-wharf/wharf-api` to `github.com/iver-wharf/wharf-api/v5`. (#128)

- BREAKING: Removed all deprecated environment variable configs, which were marked as deprecated in v4.2.0/#38. Now all environment variables require the `WHARF_` prefix. (#87)

- BREAKING: Changed the following POST creation endpoints to solely create, instead of the previous behavior where it instead could update if it found an existing database object that matched the HTTP request data: (#88, #93) 
  - `POST /project`
  - `POST /provider`
  - `POST /token`

- BREAKING: Removed RabbitMQ integration. All `mq.*` YAML configs and `WHARF_MQ_*` environment variables are no longer relevant. This may be implemented again later, but inside a new "notification" component instead of directly inside wharf-api. (#102)

- Deprecated PUT endpoints that took the object ID from the HTTP request body.  They are still supported, but may be removed in the next major release (v6.0.0). Please refer to the new endpoints that takes the ID from the URL path. (#88, #91, #94, #97, #113)

  - Use `PUT /project/{projectId}` instead of `PUT /project`
  - Use `PUT /provider/{providerId}` instead of `PUT /provider`
  - Use `PUT /token/{tokenId}` instead of `PUT /token`
  - Use `PUT /project/{projectId}/branch` instead of `PUT /branches`

- Deprecated POST search endpoints that took the search queries from the HTTP request body. They are still supported, but may be removed in the next major release (v6.0.0). Please refer to the new endpoints that use query parameter instead. (#99, #109, #118, #119, #123)

  - Use new `GET /project` instead of `GET /projects` or `POST /projects/search`
  - Use new `GET /build` instead of `GET /projects/{projectId}/builds` or `POST /builds/search`
  - Use new `GET /provider` instead of `GET /providers` or `POST /providers/search`
  - Use new `GET /token` instead of `GET /tokens` or `POST /tokens/search`
  - Use new `GET /build/{buildId}/artifact` instead of `GET /build/{buildId}/artifacts`

- Deprecated `/branch` and `/branches` endpoints in favor of new `/project/{projectId}/branch` endpoints. (#120, #121)

- Deprecated `PUT /build/{buildId}` in favor of new `PUT /build/{buildId}/status` endpoint. (#120, #121)

- Deprecated `POST /project/{projectId}/{stage}/run` in favor of new `POST /project/{projectId}/build` endpoint. (#120, #121)

- Added new GET endpoints to get list of objects (as mentioned in note above), with large set of query parameters. Major difference with their "plural" GET counterparts, they all return paginated results instead, as well as a `"totalCount"` field for the overall query.

  By default all these new endpoints use a default limit of 100, but this can be disabled by specifying `?limit=0`. (#109, #118)

- Added configuration of specific origins for CORS via the environment variable `WHARF_HTTP_CORS_ALLOWORIGINS` or the YAML key `http.cors.allowOrigins`. This is to make sending `Authorization` headers possible. (#101)

- Added a slew of options for setting OIDC parameters (see WHARF_HTTP_OIDC_*) for JWT token verification. Upon setting `WHARF_HTTP_OIDC_ENABLE=true` a check will be enforced for requests sent to the api such that all requests not carrying a valid bearer token will fail.

- Added support for Sqlite. Default database driver is still Postgres.

  Note: wharf-api must be compiled with `CGO_ENABLED=1` (which is the default for Go builds) but our Docker build is compiled with `CGO_ENABLED=0`. If you need Sqlite support in our Docker image, then please file a new issue over at <https://github.com/iver-wharf/wharf-api/issues/new>, and we will take a look at it. (#86)

- Added configuration for selecting database driver, environment variable `WHARF_DB_DRIVER` or the YAML key `db.driver`. Valid values: (#86)

  - `postgres` (default)
  - `sqlite`

- Added configuration for Sqlite file path, environment variable `WHARF_DB_PATH` or the YAML key `db.path`. Defaults to `wharf-api.db`. (#86)

- Added dependency on `gorm.io/driver/sqlite`. (#86)

- Added `updatedAt` and `createdAt` fields to the following models: (#111)

  - `response.Artifact`
  - `response.Branch`
  - `response.Build`
  - `response.Project`
  - `response.Provider`
  - `response.TestResultDetail`
  - `response.TestResultSummary`
  - `response.Token`

  Objects created and updated before this patch will have the value `null`, but will get a valid date on first update, such as on first refresh for a project.

- Fixed bug where unable to delete a Project without first deleting all child objects. (#64)

- Fixed where wharf-core logging for Gin debug and error messages were set up after they were initially used, leading to a mix of wharf-core and Gin formatted logs. (#63)

- Added database tables: (#43)

  - test_result_detail
  - test_result_summary

- Added test-result specific endpoints: (#43, #118)

  - `POST /build/{buildid}/test-result`

    This should be used instead of `POST /build/{buildid}/artifact` when uploading test result files.

  - `GET /build/{buildid}/test-result/detail`

  - `GET /build/{buildid}/test-result/summary`

  - `GET /build/{buildid}/test-result/summary/{artifactId}`

  - `GET /build/{buildid}/test-result/summary/{artifactId}/detail`

  - `GET /build/{buildid}/test-result/list-summary`

- Deprecated endpoint `GET /build/{buildid}/tests-results`.

  Use `GET /build/{buildid}/test-result/list-summary` instead. The response data is slightly different; it has additional properties, and does not have a `status` property. (#43, #77, #118)

- Changed format of all endpoint's path parameters from all lowercase to camelCase: (#76)

  - branchid -> branchId
  - projectid -> projectId
  - providerid -> providerId
  - tokenid -> tokenId
  - buildid -> buildId

  This affects the Swagger documentation, but has no behavioral implications.

- Deprecated endpoint `GET /branch/{branchId}`. Getting a single branch by its ID has not been shown to have any benefits. Please refer to the `GET /project/{projectId}` endpoint instead. (#75)

- Removed `Provider.UploadURL` and all references to it, as it was unused. (#82)

- Removed DB column `provider.upload_url`, as it was unused. (#82)

- Added `TestResultListSummary` field to `Build` database model. This allows you to avoid `N+1` HTTP requests when listing builds to show test summaries. (#80)

- Changed to preload `TestResultSummaries` field of `Build` database model. (#80)

- Added packages for "Plain Old Go Objects", with finer-grained decoupling between database, HTTP request, and HTTP response models.  The Swagger documentation is affected by this, and some unused fields have been removed from certain endpoints, such as the `tokenId` in `POST /token`.  The new packages are: (#78, #83)

  - `pkg/model/database`
  - `pkg/model/request`
  - `pkg/model/response`

- Added more backend validation on some endpoints, such as enforcing `name` field to be set when creating a new project. (#83)

- Fixed `PUT /token` where it did not use the `providerId` value from the HTTP request body. It now sets the provider's token if the field is supplied and non-zero. (#78)

- Added Swagger operation IDs to all endpoints. This has no effect on the API's behavior, but affects code generators. (#79)

- Fixed bug where projects created using the deprecated `PUT /project` endpoint would have set a null `ProviderID` in the database. (#96)

- Added Swagger attribute `minimum` to all ID path parameters, response bodies, and request bodies, as we do not support negative values there. (#98)

- Changed a lot of database columns to be `NOT NULL` where wharf-api already didn't support null/nil values. Migration steps have been added so any potential null values will be changed to empty strings or zeroes.  The updated columns are: (#100)

  - `artifact.file_name`
  - `build_param.value`
  - `param.default_value`
  - `param.value`
  - `project.avatar_url`
  - `project.build_definition`
  - `project.description`
  - `project.git_url`
  - `project.group_name`
  - `test_result_summary.file_name`
  - `token.user_name`

- Added new field `RemoteProjectID` to the project model. (#112)

- Added endpoints to allow setting manual overrides for a project. These overrides are used in responses from `GET /project` and other, as well as in build parameters for newly started builds. New endpoints: (#117, #127)

  - `GET /project/{projectId}/override` to get all overrides
  - `PUT /project/{projectId}/override` to set all overrides
  - `DELETE /project/{projectId}/override` to clear all overrides

- Changed version of `github.com/iver-wharf/wharf-core` from v1.2.0 to v1.3.0.  (#125)

- Changed Dockerfile for easier windows building. (#126)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
