### PR TITLE
Preload test result summaries and params when getting list of builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v5.0.1 (WIP)
+
+- Fixed `testResultListSummary`, `testResultSummary` and `params` not filled
+  when fetching list of builds. (#131)
+
 ## v5.0.0 (2022-01-17)
 
 - BREAKING: Changed module path from `github.com/iver-wharf/wharf-api` to

--- a/build.go
+++ b/build.go
@@ -220,7 +220,7 @@ func (m buildModule) getBuildListHandler(c *gin.Context) {
 		where.AddFieldName(database.BuildFields.StatusID)
 	}
 
-	query := m.Database.
+	query := databaseBuildPreloaded(m.Database).
 		Clauses(orderBySlice.ClauseIfNone(defaultGetBuildsOrderBy)).
 		Where(&database.Build{
 			ProjectID:   where.Uint(database.BuildFields.ProjectID, params.ProjectID),
@@ -482,10 +482,8 @@ func setStatusDate(build *database.Build, statusID database.BuildStatus) {
 
 func (m buildModule) getBuild(buildID uint) (database.Build, error) {
 	var dbBuild database.Build
-	if err := m.Database.
+	if err := databaseBuildPreloaded(m.Database).
 		Where(&database.Build{BuildID: buildID}).
-		Preload(database.BuildFields.TestResultSummaries).
-		Preload(database.BuildFields.Params).
 		First(&dbBuild).
 		Error; err != nil {
 		return database.Build{}, err
@@ -827,4 +825,10 @@ func getDBJobParams(
 
 func validateBuildExistsByID(c *gin.Context, db *gorm.DB, buildID uint, whenMsg string) bool {
 	return validateDatabaseObjExistsByID(c, db, &database.Build{}, buildID, "build", whenMsg)
+}
+
+func databaseBuildPreloaded(db *gorm.DB) *gorm.DB {
+	return db.Set("gorm:auto_preload", false).
+		Preload(database.BuildFields.TestResultSummaries).
+		Preload(database.BuildFields.Params)
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Added preloading of test result summaries and params when getting a list of builds.

## Motivation

Required to be able to show the test result list summary (currently generated from test result summaries when getting) in the builds list view in iver-wharf/wharf-web/pull/53 without making an extra request per build.

Params preloaded as well to match getting a single build, and so it can be wrapped in a function.

## Alternative solution

Keep the preloading, but empty the `TestResultSummaries` field after generating the `TestResultListSummary` to save bandwidth when there are many tests. Thoughts?

## Notes

I feel this is more of a bugfix, as I believe the idea was to have `testResultListSummary` be available _especially_ when fetching multiple builds. Hence patch-version bump.