### PR TITLE
Moved linting to Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN chmod +x deploy/update-version.sh  \
     && deploy/update-version.sh version.yaml \
     && make swag \
     && CGO_ENABLED=0 go build -o main \
-    && make test
+    && make check
 
 ARG REG=docker.io
 FROM ${REG}/library/alpine:3.14 AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,8 @@ ARG BUILD_REF="0"
 ARG BUILD_DATE=""
 RUN chmod +x deploy/update-version.sh  \
     && deploy/update-version.sh version.yaml \
-    && make swag \
-    && CGO_ENABLED=0 go build -o main \
-    && make check
+    && make swag check \
+    && CGO_ENABLED=0 go build -o main
 
 ARG REG=docker.io
 FROM ${REG}/library/alpine:3.14 AS final

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install tidy deps test \
+.PHONY: install tidy deps check \
 	docker docker-run serve swag-force swag \
 	lint lint-md lint-go \
 	lint-fix lint-md-fix
@@ -26,8 +26,8 @@ deps:
 	go mod download
 	npm install
 
-test: swag
-	go test -v ./...
+check: swag
+	go test ./...
 
 docker:
 	docker build . \

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,11 @@ tidy:
 	go mod tidy
 
 deps:
-	cd .. && go get -u github.com/swaggo/swag/cmd/swag@v1.7.1
+	go install github.com/mgechev/revive@latest
+	go install golang.org/x/tools/cmd/goimports@latest
+	go install github.com/swaggo/swag/cmd/swag@v1.7.1
 	go mod download
+	npm install
 
 test: swag
 	go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ lint-fix: lint-md-fix
 lint-md:
 	npx remark . .github
 
-lint-md-fix:
+lint-fix-md:
 	npx remark . .github -o
 
 lint-go:

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 	@# This comment silences warning "make: Nothing to be done for 'swag'."
 
 lint: lint-md lint-go
-lint-fix: lint-fix-md
+lint-fix: lint-fix-md lint-fix-go
 
 lint-md:
 	npx remark . .github

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install tidy deps check \
 	docker docker-run serve swag-force swag \
 	lint lint-md lint-go \
-	lint-fix lint-md-fix
+	lint-fix lint-fix-md
 
 commit = $(shell git rev-parse HEAD)
 version = latest
@@ -70,7 +70,7 @@ endif
 	@# This comment silences warning "make: Nothing to be done for 'swag'."
 
 lint: lint-md lint-go
-lint-fix: lint-md-fix
+lint-fix: lint-fix-md
 
 lint-md:
 	npx remark . .github

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install tidy deps check \
 	docker docker-run serve swag-force swag \
 	lint lint-md lint-go \
-	lint-fix lint-fix-md
+	lint-fix lint-fix-md lint-fix-go
 
 commit = $(shell git rev-parse HEAD)
 version = latest
@@ -79,4 +79,8 @@ lint-fix-md:
 	npx remark . .github -o
 
 lint-go:
+	goimports -d $(shell git ls-files "*.go")
 	revive -formatter stylish -config revive.toml ./...
+
+lint-fix-go:
+	goimports -d -w $(shell git ls-files "*.go")

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ docker push quay.io/iver-wharf/wharf-api:v2.0.0
 
 ## Linting
 
-Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-
 ```sh
+make deps # download linting dependencies
+
 make lint
 
 make lint-go # only lint Go code

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker push quay.io/iver-wharf/wharf-api:v2.0.0
 
 ## Linting
 
-You can lint all of the above at the same time by running:
+Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
 
 ```sh
 make lint

--- a/README.md
+++ b/README.md
@@ -71,43 +71,25 @@ docker push quay.io/iver-wharf/wharf-api:latest
 docker push quay.io/iver-wharf/wharf-api:v2.0.0
 ```
 
-## Linting Golang
-
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-- Requires Revive to be installed: <https://revive.run/>
-
-```sh
-go get -u github.com/mgechev/revive
-```
-
-```sh
-npm run lint-go
-```
-
-## Linting markdown
-
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-
-```sh
-npm install
-
-npm run lint-md
-
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-md-fix
-```
-
 ## Linting
 
 You can lint all of the above at the same time by running:
 
 ```sh
-npm run lint
+make lint
 
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-fix
+make lint-go # only lint Go code
+make lint-md # only lint Markdown files
+```
+
+Some errors can be fixed automatically. Keep in mind that this updates the
+files in place.
+
+```sh
+make lint-fix
+
+#make lint-fix-go # Go linter does not support fixes
+make lint-fix-md # only lint and fix Markdown files
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ files in place.
 ```sh
 make lint-fix
 
-#make lint-fix-go # Go linter does not support fixes
+make lint-fix-go # only lint and fix Go files
 make lint-fix-md # only lint and fix Markdown files
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,4 @@
 {
-  "scripts": {
-    "lint": "\"$npm_execpath\" run lint-md && \"$npm_execpath\" run lint-go",
-    "lint-fix": "\"$npm_execpath\" run lint-md-fix",
-    "lint-md": "remark . .github",
-    "lint-md-fix": "remark . .github -o",
-    "lint-go": "revive -formatter stylish -config revive.toml ./..."
-  },
   "devDependencies": {
     "remark-cli": "^9.0.0",
     "remark-lint": "^8.0.0",


### PR DESCRIPTION
## Summary

- Added targets to `Makefile` for linting and other utilities like cleaning
- Removed linting from NPM scripts in `package.json`
- Simplified linting docs

## Motivation

Moves focus from relying on NPM for all linting stuff over to Makefile.

Based on https://github.com/iver-wharf/wharf-cmd/pull/31
