### PR TITLE
Renamed EngineList.Default -> .DefaultEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   The deprecated trigger configs are used as defaults for the `ci.engine.url`
   and `ci.engine.token` configs.
 
-- Added endpoint `GET /api/engine` for listing execution engines. (#134)
+- Added endpoint `GET /api/engine` for listing execution engines. (#134, #140)
 
 - Added query parameter `?engine=ID` to `POST /api/project/{projectId}/build`
   to allow specifying which execution engine to use for the new build. (#134)

--- a/engine.go
+++ b/engine.go
@@ -32,7 +32,7 @@ func (m engineModule) getEngineList(c *gin.Context) {
 	var res response.EngineList
 	if defaultEng, hasDefault := getDefaultEngineFromConfig(conf); hasDefault {
 		resDefaultEng := convCIEngineToResponse(defaultEng)
-		res.Default = &resDefaultEng
+		res.DefaultEngine = &resDefaultEng
 	}
 	engines := getEnginesFromConfig(conf)
 	res.List = convCIEnginesToResponses(engines)

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -150,8 +150,8 @@ type Engine struct {
 // configured with, as well as a declaration of which one is the default engine
 // that will be used on new builds if no engine is specified.
 type EngineList struct {
-	Default *Engine  `json:"default" extensions:"x-nullable"`
-	List    []Engine `json:"list"`
+	DefaultEngine *Engine  `json:"defaultEngine" extensions:"x-nullable"`
+	List          []Engine `json:"list"`
 }
 
 // HealthStatus holds a human-readable string stating the health of the API and


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed `response.EngineList.Default` to `.DefaultEngine`

## Motivation

Fixes Swagger generated TypeScript/JavaScript code where the field was named `_default` by Swagger-codegen as `default` is a keyword in JavaScript.

Closes #139
