### PR TITLE
Changed build status query to accept arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   much quicker as it can skip applying migrations that are already
   applied. (#144)
 
+- Changed query parameter `?status` and `?statusId` in `GET /api/build` to
+  support multiple values, where it will respond with builds matching any of the
+  supplied statuses. (#150)
+
 - Changed database column name `token.token` to `token.value` due to a bug in
   the Sqlite database driver. The HTTP response model still uses the field name
   `"token"`. (#144)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ tidy:
 deps:
 	go install github.com/mgechev/revive@latest
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install github.com/swaggo/swag/cmd/swag@v1.7.1
+	go install github.com/swaggo/swag/cmd/swag@v1.8.0
 	go mod download
 	npm install
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ tidy:
 deps:
 	go install github.com/mgechev/revive@latest
 	go install golang.org/x/tools/cmd/goimports@latest
-	go install github.com/swaggo/swag/cmd/swag@v1.8.0
+	go install github.com/swaggo/swag/cmd/swag@v1.7.1
 	go mod download
 	npm install
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed `status` and `statusId` to be slices instead of single values

## Motivation

This is to allow wharf-cmd-watchdog to query for non-finished builds, as any finished builds are in either status `Completed` or `Failed`, which the API didn't support querying for before this PR.

We use the `multi` collection format, meaning to specify multiple values you specify the query parameter multiple times, such as:

```http
GET /api/build?status=Scheduling&status=Running
```

Because of this, the parameter only gains functionality and doesn't break backwards.

