### PR TITLE
Fixed URL query building

### DIFF
--- a/build.go
+++ b/build.go
@@ -773,13 +773,13 @@ func triggerBuild(dbJobParams []database.Param, engine CIEngineConfig) (string, 
 	q.Set("token", engine.Token)
 	u.RawQuery = q.Encode()
 
-	redactedUrl := &(*u)
+	redactedURL := &(*u)
 	q.Set("token", "*****")
-	redactedUrl.RawQuery = q.Encode()
+	redactedURL.RawQuery = q.Encode()
 
 	log.Info().
 		WithString("method", "POST").
-		WithString("url", redactedUrl.Redacted()).
+		WithString("url", redactedURL.Redacted()).
 		Message("Triggering build.")
 
 	resp, err := http.Post(u.String(), "", nil)

--- a/build.go
+++ b/build.go
@@ -760,23 +760,29 @@ func parseDBBuildParams(buildID uint, buildDef []byte, vars []byte) ([]database.
 }
 
 func triggerBuild(dbJobParams []database.Param, engine CIEngineConfig) (string, error) {
-	q := ""
+	u, err := url.Parse(engine.URL)
+	if err != nil {
+		return "", fmt.Errorf("parse engine URL: %w", err)
+	}
+	q := url.Values{}
 	for _, dbJobParam := range dbJobParams {
 		if dbJobParam.Value != "" {
-			q = fmt.Sprintf("%s&%s=%s", q, url.QueryEscape(dbJobParam.Name), url.QueryEscape(dbJobParam.Value))
+			q.Set(dbJobParam.Name, dbJobParam.Value)
 		}
 	}
+	q.Set("token", engine.Token)
+	u.RawQuery = q.Encode()
 
-	tokenStr := fmt.Sprintf("?token=%s", engine.Token)
+	redactedUrl := &(*u)
+	q.Set("token", "*****")
+	redactedUrl.RawQuery = q.Encode()
 
-	url := fmt.Sprintf("%s%s%s", engine.URL, tokenStr, q)
-	fmt.Printf("POSTing to url: %v\n", url)
 	log.Info().
 		WithString("method", "POST").
-		WithString("url", fmt.Sprintf("%s?token=%s%s", engine.URL, "*****", q)).
+		WithString("url", redactedUrl.Redacted()).
 		Message("Triggering build.")
 
-	var resp, err = http.Post(url, "", nil)
+	resp, err := http.Post(u.String(), "", nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

- Changed the trigger URL building to use proper URL building.

## Motivation

Less prone to glitches and security vulnerabilities.

For example, if the engine URL before had a fragment, then it ruined the URL building:

```
http://jenkins.local/trigger#foo
// got turned into:
http://jenkins.local/trigger#foo?token=abc&stage=def&environment=etc
```

While now it correctly edits the correct part:
```
http://jenkins.local/trigger#foo
// now gets turned into:
http://jenkins.local/trigger?token=abc&stage=def&environment=etc#foo
```
