### PR TITLE
Added back foreign key constrain-less migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v5.1.1 (WIP)
+
+- Fixed bug of failing migrations that was introduced in v5.1.0. (#161)
+
 ## v5.1.0 (2022-03-04)
 
 - Deprecated trigger configs (YAML: `ci.triggerUrl` &amp; `ci.triggerToken`,

--- a/migrations.go
+++ b/migrations.go
@@ -32,13 +32,19 @@ func migrateInitSchema(db *gorm.DB) error {
 	if err := migrateBeforeGormigrate(db); err != nil {
 		return err
 	}
-	return db.AutoMigrate(
+	tables := []interface{}{
 		&database.Token{}, &database.Provider{},
 		&database.Project{}, &database.ProjectOverrides{},
 		&database.Branch{}, &database.Build{}, &database.Log{},
 		&database.Artifact{}, &database.BuildParam{}, &database.Param{},
 		&database.TestResultDetail{}, &database.TestResultSummary{},
-	)
+	}
+	db.DisableForeignKeyConstraintWhenMigrating = true
+	if err := db.AutoMigrate(tables...); err != nil {
+		return err
+	}
+	db.DisableForeignKeyConstraintWhenMigrating = false
+	return db.AutoMigrate(tables...)
 }
 
 func newMigrator(db *gorm.DB) *gormigrate.Gormigrate {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed failing migrations caused by foreign key constraints

## Motivation

I was comparing v5.0.0 and v5.1.0 in https://github.com/iver-wharf/wharf-api/compare/v5.0.0...v5.1.0diff-7807f0304222cb1bf359da44be1f2d3ce9beeea04d8c499192a46da74c3af820 and saw that one key difference is that I in #144 removed the double-migration, first without foreign key constraints, and then again with them.

It turns out our foreign key constraints has some circular dependencies. Fixing the database relations is postponed into #146. This PR is a band-aid fix.

I've now properly tested this in docker-compose using Postgres, as I should've done before.

Closes #160
