### PR TITLE
Fixed token always getting redacted

### DIFF
--- a/build.go
+++ b/build.go
@@ -912,7 +912,7 @@ func triggerBuild(dbJobParams []database.Param, engine CIEngineConfig) (string, 
 	u.RawQuery = q.Encode()
 
 	redactedURL := *u
-	q.Set("token", "*****")
+	q.Set("token", "~~redacted~~")
 	redactedURL.RawQuery = q.Encode()
 
 	log.Info().

--- a/build.go
+++ b/build.go
@@ -836,7 +836,6 @@ func (m buildModule) startBuildHandler(c *gin.Context, projectID uint, stageName
 	}
 
 	renderJSON(c, http.StatusOK, modelconv.DBBuildToResponseBuildReferenceWrapper(dbBuild))
-	c.JSON(http.StatusOK, modelconv.DBBuildToResponseBuildReferenceWrapper(dbBuild))
 }
 
 func (m buildModule) SaveBuildParams(dbParams []database.BuildParam) error {
@@ -912,7 +911,7 @@ func triggerBuild(dbJobParams []database.Param, engine CIEngineConfig) (string, 
 	q.Set("token", engine.Token)
 	u.RawQuery = q.Encode()
 
-	redactedURL := &(*u)
+	redactedURL := *u
 	q.Set("token", "*****")
 	redactedURL.RawQuery = q.Encode()
 
@@ -921,6 +920,7 @@ func triggerBuild(dbJobParams []database.Param, engine CIEngineConfig) (string, 
 		WithString("url", redactedURL.Redacted()).
 		Message("Triggering build.")
 
+	log.Info().WithString("url", u.String()).Message("Real URL.")
 	resp, err := http.Post(u.String(), "", nil)
 	if err != nil {
 		return "", err

--- a/build.go
+++ b/build.go
@@ -912,6 +912,7 @@ func triggerBuild(dbJobParams []database.Param, engine CIEngineConfig) (string, 
 	u.RawQuery = q.Encode()
 
 	redactedURL := *u
+	redactedURL.User = nil
 	q.Set("token", "~~redacted~~")
 	redactedURL.RawQuery = q.Encode()
 


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed actual trigger URL used also getting censored

## Motivation

Apparently you cannot make a copy by doing `&(*u)`.

Doesn't matter much as we can just use the dereferenced variant.

Also changed the redacted text as `*****` gets logged as `%2A%2A%2A%2A%2A`, while `~redacted~` isn't escaped.
