### PR TITLE
Disabled auto indent for desktops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v5.1.3 (WIP)
+
+- Changed automatic JSON indentation in HTTP responses based on the user agent,
+  so it no longer automatically indents for desktop, mobile, or tablet devices.
+  It is still enabled for cURL and if the `?pretty` flag is set. (#170)
+
 ## v5.1.2 (2022-03-08)
 
 - Fixed token in trigger URL used in HTTP request getting redacted, instead of

--- a/utils_gin.go
+++ b/utils_gin.go
@@ -45,21 +45,18 @@ func parseCommonOrderBySlice(c *gin.Context, orders []string, fieldToColumnNames
 }
 
 func renderJSON(c *gin.Context, code int, response interface{}) {
-	indent := false
-	prettyQuery, ok := c.GetQuery("pretty")
-	if ok {
-		if prettyQuery == "" || strings.EqualFold(prettyQuery, "true") {
-			indent = true
-		}
-	} else {
-		agent := ua.Parse(c.Request.UserAgent())
-		if agent.Name == "curl" || agent.Desktop || agent.Mobile || agent.Tablet {
-			indent = true
-		}
-	}
-	if indent {
+	if shouldIndentJSONResponse(c) {
 		c.IndentedJSON(code, response)
 	} else {
 		c.JSON(code, response)
 	}
+}
+
+func shouldIndentJSONResponse(c *gin.Context) bool {
+	prettyQuery, ok := c.GetQuery("pretty")
+	if ok {
+		return prettyQuery == "" || strings.EqualFold(prettyQuery, "true")
+	}
+	agent := ua.Parse(c.Request.UserAgent())
+	return agent.Name == "curl"
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Disabled the auto-JSON indent in HTTP responses for web browsers

## Motivation

Forgot that AJAX requests contains the browser's user agent, so the requests that wharf-web did was indented.
