### PR TITLE
Reorganized go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,13 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/iver-wharf/wharf-core v1.3.0
 	github.com/mileusna/useragent v1.0.2
+	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.7.0
 	github.com/swaggo/gin-swagger v1.4.1
 	github.com/swaggo/swag v1.8.1
+	golang.org/x/text v0.3.7
+	google.golang.org/grpc v1.44.0
+	google.golang.org/protobuf v1.27.1
 	gopkg.in/guregu/null.v4 v4.0.0
 	gopkg.in/typ.v3 v3.0.1
 	gorm.io/driver/postgres v1.2.3
@@ -63,7 +67,6 @@ require (
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
@@ -74,11 +77,8 @@ require (
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220325170049-de3da57026de // indirect
 	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
-	golang.org/x/text v0.3.7
 	golang.org/x/tools v0.1.10 // indirect
 	google.golang.org/genproto v0.0.0-20220217155828-d576998c0009 // indirect
-	google.golang.org/grpc v1.44.0
-	google.golang.org/protobuf v1.27.1
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect


### PR DESCRIPTION
## Summary

- Reorganized so all non-indirect and indirect are in their respective `require` blocks inside go.mod

## Motivation

Thought `go mod tidy` did this for us, but appears not when dependencies goes from `// indirect` to not.
