### PR TITLE
Fix grpc logs stream skipping if slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `golang.org/x/text` v0.3.7 (#173)
   - `gopkg.in/typ.v3` v3.0.1. (#172)
 
+- Fixed gRPC logs streaming silently ignoring all logs after a pause between
+  log lines. (#175)
+
 ## v5.1.2 (2022-03-08)
 
 - Fixed token in trigger URL used in HTTP request getting redacted, instead of


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed gRPC logs stream ignoring logs if writer is slow.

## Motivation

The logs coming from wharf-cmd-worker -> wharf-cmd-aggregator -> wharf-api are not a steady stream. The previous implementation failed as soon as there was a pause in the logs stream.

This fixes that.
