### PR TITLE
Fixed updated build object not in response when updating build status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Fixed gRPC logs streaming silently ignoring all logs after a pause between
   log lines. (#175, #180)
 
+- Fixed `PUT /api/build/{buildId}/status` not returning the resulting updated
+  build object. (#?)
+
 ## v5.1.2 (2022-03-08)
 
 - Fixed token in trigger URL used in HTTP request getting redacted, instead of

--- a/build.go
+++ b/build.go
@@ -429,7 +429,7 @@ func (m buildModule) createBuildLogHandler(c *gin.Context) {
 // @accept json
 // @param buildId path uint true "Build ID" minimum(0)
 // @param data body request.BuildStatusUpdate true "Status update"
-// @success 204 "Updated"
+// @success 200 {object} response.Build
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 404 {object} problem.Response "Build not found"
@@ -457,14 +457,14 @@ func (m buildModule) updateBuildStatusHandler(c *gin.Context) {
 			reqStatusUpdate.Status,
 		))
 	}
-	_, err := m.updateBuildStatus(buildID, dbBuildStatus)
+	updatedBuild, err := m.updateBuildStatus(buildID, dbBuildStatus)
 	if err != nil {
 		ginutil.WriteDBWriteError(c, err, fmt.Sprintf(
 			"Failed updating status on build with ID %d to status with ID %d.",
 			buildID, dbBuildStatus))
 		return
 	}
-	c.Status(http.StatusNoContent)
+	c.JSON(http.StatusOK, modelconv.DBBuildToResponse(updatedBuild, m.engineLookup))
 }
 
 func (m buildModule) updateBuildStatus(buildID uint, statusID database.BuildStatus) (database.Build, error) {

--- a/build.go
+++ b/build.go
@@ -429,7 +429,7 @@ func (m buildModule) createBuildLogHandler(c *gin.Context) {
 // @accept json
 // @param buildId path uint true "Build ID" minimum(0)
 // @param data body request.BuildStatusUpdate true "Status update"
-// @success 200 {object} response.Build
+// @success 200 {object} response.Build "Updated build status"
 // @failure 400 {object} problem.Response "Bad request"
 // @failure 401 {object} problem.Response "Unauthorized or missing jwt token"
 // @failure 404 {object} problem.Response "Build not found"


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed to return `response.Build` on successful `PUT /api/build/{buildId}/status` request.
  - Also changed status code to `200 (OK)`.

## Motivation

Closes #179
