### PR TITLE
Release v5.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v5.1.3 (WIP)
+## v5.1.3 (2022-05-05)
 
 - Changed automatic JSON indentation in HTTP responses based on the user agent,
   so it no longer automatically indents for desktop, mobile, or tablet devices.


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Changed automatic JSON indentation in HTTP responses based on the user agent, so it no longer automatically indents for desktop, mobile, or tablet devices. It is still enabled for cURL and if the `?pretty` flag is set. (#170)

- Changed Go runtime from v1.17 to v1.18. (#171)

- Changed version of `github.com/swaggo/swag` from v1.8.0 to v1.8.1. (#171)

- Added dependencies:

  - `golang.org/x/text` v0.3.7 (#173)
  - `gopkg.in/typ.v4` v4.1.0. (#172, #181)

- Fixed gRPC logs streaming silently ignoring all logs after a pause between log lines. (#175, #180)

- Fixed `PUT /api/build/{buildId}/status` not returning the resulting updated build object, and changed to return status code `200 (OK)` instead of `204 (No Content)` on success. (#183)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
