### PR TITLE
Added engine API ID in response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v5.2.0 (WIP)
+
+- Added `api` field to engine response (in e.g `GET /api/engine`) that was added
+  to the configuration in v5.1.0/#156. The field can currently only have two
+  different values: (#185)
+
+  - `"jenkins-generic-webhook-trigger"`: Jenkins Generic Webhook Trigger plugin:
+    https://plugins.jenkins.io/generic-webhook-trigger/
+
+  - `"wharf-cmd.v1"`: wharf-cmd-provisioner REST interface v1, which is an
+    extension of the jenkins-generic-webhook-trigger. The `build.workerId` is
+    only set in the database if the engine API is of this type.
+
 ## v5.1.3 (2022-05-05)
 
 - Changed automatic JSON indentation in HTTP responses based on the user agent,

--- a/engine.go
+++ b/engine.go
@@ -96,6 +96,7 @@ func convCIEngineToResponse(engine CIEngineConfig) response.Engine {
 		ID:   engine.ID,
 		Name: engine.Name,
 		URL:  engine.URL,
+		API:  string(engine.API),
 	}
 }
 

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -145,6 +145,7 @@ type Engine struct {
 	ID   string `json:"id" example:"primary"`
 	Name string `json:"name" example:"Primary"`
 	URL  string `json:"url" example:"http://wharf-cmd-provisioner/trigger"`
+	API  string `json:"api" example:"wharf-cmd.v1"`
 }
 
 // EngineList contains a list of execution engines that the wharf-api is


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `response.Engine.API` field, using `CIEngineConfig.API`

## Motivation

Good info to provide. Seems to have forgotten to add it to the response when I added the API field to CIEngineConfig
