### PR TITLE
Fixed SafeSQLName not getting read correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
     extension of the jenkins-generic-webhook-trigger. The `build.workerId` is
     only set in the database if the engine API is of this type.
 
+- Fixed `PUT /api/project/{projectId}/branch` where it created invalid SQL
+  statements to delete old branches. (#186)
+
 ## v5.1.3 (2022-05-05)
 
 - Changed automatic JSON indentation in HTTP responses based on the user agent,

--- a/pkg/model/database/database.go
+++ b/pkg/model/database/database.go
@@ -41,7 +41,7 @@ type TimeMetadata struct {
 //
 // It is merely semantical and has no validation attached. Values of this type
 // should never be constructed from user input.
-type SafeSQLName string
+type SafeSQLName = string
 
 // ProviderFields holds the Go struct field names for each field.
 // Useful in GORM .Where() statements to only select certain fields or in GORM


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed `SafeSQLName` messing up GORM `.Where` statements

## Motivation

In GORM:

```go
db.Where("name IN ?", []any{"a", "b", "c"})
```

Is a shortcut for:

```go
db.Where(db.Raw("name IN ?", []any{"a", "b", "c"}))
```

But that only works if the first argument is a string.

It was not a string, it was a `SafeSQLName`, which was based on a string, but that didn't GORM understand.

Now `SafeSQLName` is a type alias instead of it's own type, so reflection doesn't see them as different types.
