### PR TITLE
Release v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v5.2.0 (WIP)
+## v5.2.0 (2022-05-10)
 
 - Added `api` field to engine response (in e.g `GET /api/engine`) that was added
   to the configuration in v5.1.0/#156. The field can currently only have two


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Added `api` field to engine response (in e.g `GET /api/engine`) that was added to the configuration in v5.1.0/#156. The field can currently only have two different values: (#185)

  - `"jenkins-generic-webhook-trigger"`: Jenkins Generic Webhook Trigger plugin: https://plugins.jenkins.io/generic-webhook-trigger/

  - `"wharf-cmd.v1"`: wharf-cmd-provisioner REST interface v1, which is an extension of the jenkins-generic-webhook-trigger. The `build.workerId` is only set in the database if the engine API is of this type.

- Fixed `PUT /api/project/{projectId}/branch` where it created invalid SQL statements to delete old branches. (#186)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
